### PR TITLE
Variant2

### DIFF
--- a/include/foxy/detail/has_token.hpp
+++ b/include/foxy/detail/has_token.hpp
@@ -40,15 +40,12 @@ has_foxy_via(boost::beast::http::basic_fields<Allocator> const& fields) -> bool
 
   auto found = false;
   for (; begin != end; ++begin) {
-    std::cout << "parsing this value...\n" << begin->value() << "\n";
-
     auto       field_val_iter = begin->value().begin();
     auto const field_val_end  = begin->value().end();
 
     found = x3::parse(field_val_iter, field_val_end,
                       x3::no_case[*(x3::char_ - "1.1 foxy") >> x3::lit("1.1 foxy") >> *x3::char_]);
 
-    std::cout << "found: " << std::boolalpha << found << "\n\n";
     if (found) { break; }
   }
   return found;

--- a/include/foxy/detail/mp11/detail/config.hpp
+++ b/include/foxy/detail/mp11/detail/config.hpp
@@ -1,0 +1,153 @@
+// snapshot of commit:
+// https://github.com/boostorg/mp11/blob/8e60b42fa037253f0f515b57d790aa67a47f308e/include/boost/mp11/detail/config.hpp
+//
+
+#ifndef BOOST_MP11_DETAIL_CONFIG_HPP_INCLUDED
+#define BOOST_MP11_DETAIL_CONFIG_HPP_INCLUDED
+
+// Copyright 2016, 2018, 2019 Peter Dimov.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+// BOOST_MP11_WORKAROUND
+
+#if defined(BOOST_STRICT_CONFIG) || defined(BOOST_MP11_NO_WORKAROUNDS)
+
+#define BOOST_MP11_WORKAROUND(symbol, test) 0
+
+#else
+
+#define BOOST_MP11_WORKAROUND(symbol, test) ((symbol) != 0 && ((symbol) test))
+
+#endif
+
+//
+
+#define BOOST_MP11_CUDA 0
+#define BOOST_MP11_CLANG 0
+#define BOOST_MP11_INTEL 0
+#define BOOST_MP11_GCC 0
+#define BOOST_MP11_MSVC 0
+
+#define BOOST_MP11_CONSTEXPR constexpr
+
+#if defined(__CUDACC__)
+
+// nvcc
+
+#undef BOOST_MP11_CUDA
+#define BOOST_MP11_CUDA \
+  (__CUDACC_VER_MAJOR__ * 1000000 + __CUDACC_VER_MINOR__ * 10000 + __CUDACC_VER_BUILD__)
+
+// CUDA (8.0) has no constexpr support in msvc mode:
+#if defined(_MSC_VER) && (BOOST_MP11_CUDA < 9000000)
+
+#define BOOST_MP11_NO_CONSTEXPR
+
+#undef BOOST_MP11_CONSTEXPR
+#define BOOST_MP11_CONSTEXPR
+
+#endif
+
+#elif defined(__clang__)
+
+// Clang
+
+#undef BOOST_MP11_CLANG
+#define BOOST_MP11_CLANG (__clang_major__ * 100 + __clang_minor__)
+
+#if defined(__has_cpp_attribute)
+#if __has_cpp_attribute(fallthrough) && __cplusplus >= 201406L // Clang 3.9+ in c++1z mode
+#define BOOST_MP11_HAS_FOLD_EXPRESSIONS
+#endif
+#endif
+
+#if BOOST_MP11_CLANG < 400 && __cplusplus >= 201402L && defined(__GLIBCXX__) && !__has_include(<shared_mutex>)
+
+// Clang pre-4 in C++14 mode, libstdc++ pre-4.9, ::gets is not defined,
+// but Clang tries to import it into std
+
+extern "C" char *
+gets(char *__s);
+#endif
+
+#elif defined(__INTEL_COMPILER)
+
+// Intel C++
+
+#undef BOOST_MP11_INTEL
+#define BOOST_MP11_INTEL __INTEL_COMPILER
+
+#elif defined(__GNUC__)
+
+// g++
+
+#undef BOOST_MP11_GCC
+#define BOOST_MP11_GCC (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+#elif defined(_MSC_VER)
+
+// MS Visual C++
+
+#undef BOOST_MP11_MSVC
+#define BOOST_MP11_MSVC _MSC_VER
+
+#if BOOST_MP11_WORKAROUND(BOOST_MP11_MSVC, < 1920)
+#define BOOST_MP11_NO_CONSTEXPR
+#endif
+
+#if _MSC_FULL_VER < 190024210 // 2015u3
+#undef BOOST_MP11_CONSTEXPR
+#define BOOST_MP11_CONSTEXPR
+#endif
+
+#endif
+
+// BOOST_MP11_HAS_CXX14_CONSTEXPR
+
+#if !defined(BOOST_MP11_NO_CONSTEXPR) && defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#define BOOST_MP11_HAS_CXX14_CONSTEXPR
+#endif
+
+// BOOST_MP11_HAS_FOLD_EXPRESSIONS
+
+#if !defined(BOOST_MP11_HAS_FOLD_EXPRESSIONS) && defined(__cpp_fold_expressions) && \
+  __cpp_fold_expressions >= 201603
+#define BOOST_MP11_HAS_FOLD_EXPRESSIONS
+#endif
+
+// BOOST_MP11_HAS_TYPE_PACK_ELEMENT
+
+#if defined(__has_builtin)
+#if __has_builtin(__type_pack_element)
+#define BOOST_MP11_HAS_TYPE_PACK_ELEMENT
+#endif
+#endif
+
+// BOOST_MP11_DEPRECATED(msg)
+
+#if BOOST_MP11_WORKAROUND(BOOST_MP11_MSVC, < 1900)
+#define BOOST_MP11_DEPRECATED(msg)
+#elif BOOST_MP11_WORKAROUND(BOOST_MP11_GCC, < 50000)
+#define BOOST_MP11_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif BOOST_MP11_CLANG
+#if defined(__has_cpp_attribute)
+// 3.8 warns about [[deprecated]] when in C++11 mode
+// so we only use it on 3.9 and above, detected via [[fallthrough]]
+// can't version check because Apple
+#if __has_cpp_attribute(deprecated) && __has_cpp_attribute(fallthrough)
+#define BOOST_MP11_DEPRECATED(msg) [[deprecated(msg)]]
+#else
+#define BOOST_MP11_DEPRECATED(msg)
+#endif
+#else // defined(__has_cpp_attribute)
+#define BOOST_MP11_DEPRECATED(msg)
+#endif
+#else
+#define BOOST_MP11_DEPRECATED(msg) [[deprecated(msg)]]
+#endif
+
+#endif // #ifndef BOOST_MP11_DETAIL_CONFIG_HPP_INCLUDED

--- a/include/foxy/detail/mp11/function.hpp
+++ b/include/foxy/detail/mp11/function.hpp
@@ -1,0 +1,254 @@
+// snapshot of commit:
+// https://github.com/boostorg/mp11/blob/f7ca2842c38c8b533fd5e804302f681d94c5abd6/include/boost/mp11/function.hpp
+//
+
+#ifndef BOOST_MP11_FUNCTION_HPP_INCLUDED
+#define BOOST_MP11_FUNCTION_HPP_INCLUDED
+
+// Copyright 2015-2019 Peter Dimov.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/mp11/integral.hpp>
+#include <foxy/detail/mp11/utility.hpp>
+#include <boost/mp11/detail/mp_list.hpp>
+#include <boost/mp11/detail/mp_count.hpp>
+#include <boost/mp11/detail/mp_plus.hpp>
+#include <boost/mp11/detail/mp_min_element.hpp>
+#include <boost/mp11/detail/mp_void.hpp>
+#include <foxy/detail/mp11/detail/config.hpp>
+#include <type_traits>
+
+namespace boost
+{
+namespace mp11
+{
+// mp_void<T...>
+//   in detail/mp_void.hpp
+
+// mp_and<T...>
+#if BOOST_MP11_WORKAROUND(BOOST_MP11_MSVC, < 1910)
+
+namespace detail
+{
+template <class... T>
+struct mp_and_impl;
+
+} // namespace detail
+
+template <class... T>
+using mp_and = mp_to_bool<typename detail::mp_and_impl<T...>::type>;
+
+namespace detail
+{
+template <>
+struct mp_and_impl<>
+{
+  using type = mp_true;
+};
+
+template <class T>
+struct mp_and_impl<T>
+{
+  using type = T;
+};
+
+template <class T1, class... T>
+struct mp_and_impl<T1, T...>
+{
+  using type = mp_eval_if<mp_not<T1>, T1, mp_and, T...>;
+};
+
+} // namespace detail
+
+#else
+
+namespace detail
+{
+template <class L, class E = void>
+struct mp_and_impl
+{
+  using type = mp_false;
+};
+
+template <class... T>
+struct mp_and_impl<mp_list<T...>, mp_void<mp_if<T, void>...>>
+{
+  using type = mp_true;
+};
+
+} // namespace detail
+
+template <class... T>
+using mp_and = typename detail::mp_and_impl<mp_list<T...>>::type;
+
+#endif
+
+// mp_all<T...>
+#if BOOST_MP11_WORKAROUND(BOOST_MP11_MSVC, < 1920) || \
+  BOOST_MP11_WORKAROUND(BOOST_MP11_GCC, < 100000)
+
+template <class... T>
+using mp_all = mp_bool<mp_count_if<mp_list<T...>, mp_not>::value == 0>;
+
+#elif defined(BOOST_MP11_HAS_FOLD_EXPRESSIONS)
+
+template <class... T>
+using mp_all = mp_bool<(static_cast<bool>(T::value) && ...)>;
+
+#else
+
+template <class... T>
+using mp_all = mp_and<mp_to_bool<T>...>;
+
+#endif
+
+// mp_or<T...>
+namespace detail
+{
+template <class... T>
+struct mp_or_impl;
+
+} // namespace detail
+
+template <class... T>
+using mp_or = mp_to_bool<typename detail::mp_or_impl<T...>::type>;
+
+namespace detail
+{
+template <>
+struct mp_or_impl<>
+{
+  using type = mp_false;
+};
+
+template <class T>
+struct mp_or_impl<T>
+{
+  using type = T;
+};
+
+template <class T1, class... T>
+struct mp_or_impl<T1, T...>
+{
+  using type = mp_eval_if<T1, T1, mp_or, T...>;
+};
+
+} // namespace detail
+
+// mp_any<T...>
+#if defined(BOOST_MP11_HAS_FOLD_EXPRESSIONS) &&       \
+  !BOOST_MP11_WORKAROUND(BOOST_MP11_GCC, < 100000) && \
+  !BOOST_MP11_WORKAROUND(BOOST_MP11_MSVC, < 1920)
+
+template <class... T>
+using mp_any = mp_bool<(static_cast<bool>(T::value) || ...)>;
+
+#else
+
+template <class... T>
+using mp_any = mp_bool<mp_count_if<mp_list<T...>, mp_to_bool>::value != 0>;
+
+#endif
+
+// mp_same<T...>
+namespace detail
+{
+template <class... T>
+struct mp_same_impl;
+
+template <>
+struct mp_same_impl<>
+{
+  using type = mp_true;
+};
+
+template <class T1, class... T>
+struct mp_same_impl<T1, T...>
+{
+  using type = mp_all<std::is_same<T1, T>...>;
+};
+
+} // namespace detail
+
+template <class... T>
+using mp_same = typename detail::mp_same_impl<T...>::type;
+
+// mp_similar<T...>
+namespace detail
+{
+template <class... T>
+struct mp_similar_impl;
+
+template <>
+struct mp_similar_impl<>
+{
+  using type = mp_true;
+};
+
+template <class T>
+struct mp_similar_impl<T>
+{
+  using type = mp_true;
+};
+
+template <class T>
+struct mp_similar_impl<T, T>
+{
+  using type = mp_true;
+};
+
+template <class T1, class T2>
+struct mp_similar_impl<T1, T2>
+{
+  using type = mp_false;
+};
+
+template <template <class...> class L, class... T1, class... T2>
+struct mp_similar_impl<L<T1...>, L<T2...>>
+{
+  using type = mp_true;
+};
+
+template <class T1, class T2, class T3, class... T>
+struct mp_similar_impl<T1, T2, T3, T...>
+{
+  using type = mp_all<typename mp_similar_impl<T1, T2>::type,
+                      typename mp_similar_impl<T1, T3>::type,
+                      typename mp_similar_impl<T1, T>::type...>;
+};
+
+} // namespace detail
+
+template <class... T>
+using mp_similar = typename detail::mp_similar_impl<T...>::type;
+
+#if BOOST_MP11_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#endif
+
+// mp_less<T1, T2>
+template <class T1, class T2>
+using mp_less = mp_bool<(T1::value < 0 && T2::value >= 0) ||
+                        ((T1::value < T2::value) && !(T1::value >= 0 && T2::value < 0))>;
+
+#if BOOST_MP11_GCC
+#pragma GCC diagnostic pop
+#endif
+
+// mp_min<T...>
+template <class T1, class... T>
+using mp_min = mp_min_element<mp_list<T1, T...>, mp_less>;
+
+// mp_max<T...>
+template <class T1, class... T>
+using mp_max = mp_max_element<mp_list<T1, T...>, mp_less>;
+
+} // namespace mp11
+} // namespace boost
+
+#endif // #ifndef BOOST_MP11_FUNCTION_HPP_INCLUDED

--- a/include/foxy/detail/mp11/utility.hpp
+++ b/include/foxy/detail/mp11/utility.hpp
@@ -1,0 +1,291 @@
+// snapshot of commit:
+// https://github.com/boostorg/mp11/blob/fc8bfcf601c35b0cc4e337be2f59f2a16912af5e/include/boost/mp11/utility.hpp
+//
+
+#ifndef BOOST_MP11_UTILITY_HPP_INCLUDED
+#define BOOST_MP11_UTILITY_HPP_INCLUDED
+
+// Copyright 2015, 2017, 2019 Peter Dimov.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/mp11/integral.hpp>
+
+// note this is the only line we've had to change for this file
+//
+#include <foxy/detail/mp11/detail/config.hpp>
+
+namespace boost
+{
+namespace mp11
+{
+// mp_identity
+template <class T>
+struct mp_identity
+{
+  using type = T;
+};
+
+// mp_identity_t
+template <class T>
+using mp_identity_t = typename mp_identity<T>::type;
+
+// mp_inherit
+template <class... T>
+struct mp_inherit : T...
+{
+};
+
+// mp_if, mp_if_c
+namespace detail
+{
+template <bool C, class T, class... E>
+struct mp_if_c_impl
+{
+};
+
+template <class T, class... E>
+struct mp_if_c_impl<true, T, E...>
+{
+  using type = T;
+};
+
+template <class T, class E>
+struct mp_if_c_impl<false, T, E>
+{
+  using type = E;
+};
+
+} // namespace detail
+
+template <bool C, class T, class... E>
+using mp_if_c = typename detail::mp_if_c_impl<C, T, E...>::type;
+template <class C, class T, class... E>
+using mp_if = typename detail::mp_if_c_impl<static_cast<bool>(C::value), T, E...>::type;
+
+// mp_valid
+
+#if BOOST_MP11_WORKAROUND(BOOST_MP11_INTEL, != 0) // tested at 1800
+
+// contributed by Roland Schulz in https://github.com/boostorg/mp11/issues/17
+
+namespace detail
+{
+template <class...>
+using void_t = void;
+
+template <class, template <class...> class F, class... T>
+struct mp_valid_impl : mp_false
+{
+};
+
+template <template <class...> class F, class... T>
+struct mp_valid_impl<void_t<F<T...>>, F, T...> : mp_true
+{
+};
+
+} // namespace detail
+
+template <template <class...> class F, class... T>
+using mp_valid = typename detail::mp_valid_impl<void, F, T...>;
+
+#else
+
+// implementation by Bruno Dutra (by the name is_evaluable)
+namespace detail
+{
+template <template <class...> class F, class... T>
+struct mp_valid_impl
+{
+  template <template <class...> class G, class = G<T...>>
+  static mp_true
+  check(int);
+  template <template <class...> class>
+  static mp_false
+  check(...);
+
+  using type = decltype(check<F>(0));
+};
+
+} // namespace detail
+
+template <template <class...> class F, class... T>
+using mp_valid = typename detail::mp_valid_impl<F, T...>::type;
+
+#endif
+
+template <class Q, class... T>
+using mp_valid_q = mp_valid<Q::template fn, T...>;
+
+// mp_defer
+namespace detail
+{
+template <template <class...> class F, class... T>
+struct mp_defer_impl
+{
+  using type = F<T...>;
+};
+
+struct mp_no_type
+{
+};
+
+#if BOOST_MP11_WORKAROUND(BOOST_MP11_CUDA, >= 9000000 && BOOST_MP11_CUDA < 10000000)
+
+template <template <class...> class F, class... T>
+struct mp_defer_cuda_workaround
+{
+  using type = mp_if<mp_valid<F, T...>, detail::mp_defer_impl<F, T...>, detail::mp_no_type>;
+};
+
+#endif
+
+} // namespace detail
+
+#if BOOST_MP11_WORKAROUND(BOOST_MP11_CUDA, >= 9000000 && BOOST_MP11_CUDA < 10000000)
+
+template <template <class...> class F, class... T>
+using mp_defer = typename detail::mp_defer_cuda_workaround<F, T...>::type;
+
+#else
+
+template <template <class...> class F, class... T>
+using mp_defer = mp_if<mp_valid<F, T...>, detail::mp_defer_impl<F, T...>, detail::mp_no_type>;
+
+#endif
+
+// mp_eval_if, mp_eval_if_c
+namespace detail
+{
+template <bool C, class T, template <class...> class F, class... U>
+struct mp_eval_if_c_impl;
+
+template <class T, template <class...> class F, class... U>
+struct mp_eval_if_c_impl<true, T, F, U...>
+{
+  using type = T;
+};
+
+template <class T, template <class...> class F, class... U>
+struct mp_eval_if_c_impl<false, T, F, U...> : mp_defer<F, U...>
+{
+};
+
+} // namespace detail
+
+template <bool C, class T, template <class...> class F, class... U>
+using mp_eval_if_c = typename detail::mp_eval_if_c_impl<C, T, F, U...>::type;
+template <class C, class T, template <class...> class F, class... U>
+using mp_eval_if =
+  typename detail::mp_eval_if_c_impl<static_cast<bool>(C::value), T, F, U...>::type;
+template <class C, class T, class Q, class... U>
+using mp_eval_if_q =
+  typename detail::mp_eval_if_c_impl<static_cast<bool>(C::value), T, Q::template fn, U...>::type;
+
+// mp_eval_if_not
+template <class C, class T, template <class...> class F, class... U>
+using mp_eval_if_not = mp_eval_if<mp_not<C>, T, F, U...>;
+template <class C, class T, class Q, class... U>
+using mp_eval_if_not_q = mp_eval_if<mp_not<C>, T, Q::template fn, U...>;
+
+// mp_eval_or
+template <class T, template <class...> class F, class... U>
+using mp_eval_or = mp_eval_if_not<mp_valid<F, U...>, T, F, U...>;
+template <class T, class Q, class... U>
+using mp_eval_or_q = mp_eval_or<T, Q::template fn, U...>;
+
+// mp_cond
+
+// so elegant; so doesn't work
+// template<class C, class T, class... E> using mp_cond = mp_eval_if<C, T, mp_cond, E...>;
+
+namespace detail
+{
+template <class C, class T, class... E>
+struct mp_cond_impl;
+
+} // namespace detail
+
+template <class C, class T, class... E>
+using mp_cond = typename detail::mp_cond_impl<C, T, E...>::type;
+
+namespace detail
+{
+template <class C, class T, class... E>
+using mp_cond_ = mp_eval_if<C, T, mp_cond, E...>;
+
+template <class C, class T, class... E>
+struct mp_cond_impl : mp_defer<mp_cond_, C, T, E...>
+{
+};
+
+} // namespace detail
+
+// mp_quote
+template <template <class...> class F>
+struct mp_quote
+{
+  // the indirection through mp_defer works around the language inability
+  // to expand T... into a fixed parameter list of an alias template
+
+  template <class... T>
+  using fn = typename mp_defer<F, T...>::type;
+};
+
+// mp_quote_trait
+template <template <class...> class F>
+struct mp_quote_trait
+{
+  template <class... T>
+  using fn = typename F<T...>::type;
+};
+
+// mp_invoke_q
+#if BOOST_MP11_WORKAROUND(BOOST_MP11_MSVC, < 1900)
+
+namespace detail
+{
+template <class Q, class... T>
+struct mp_invoke_q_impl : mp_defer<Q::template fn, T...>
+{
+};
+
+} // namespace detail
+
+template <class Q, class... T>
+using mp_invoke_q = typename detail::mp_invoke_q_impl<Q, T...>::type;
+
+#elif BOOST_MP11_WORKAROUND(BOOST_MP11_GCC, < 50000)
+
+template <class Q, class... T>
+using mp_invoke_q = typename mp_defer<Q::template fn, T...>::type;
+
+#else
+
+template <class Q, class... T>
+using mp_invoke_q = typename Q::template fn<T...>;
+
+#endif
+
+// old name for mp_invoke_q retained for compatibility, but deprecated
+template <class Q, class... T>
+using mp_invoke BOOST_MP11_DEPRECATED("please use mp_invoke_q") = mp_invoke_q<Q, T...>;
+
+// mp_not_fn<P>
+template <template <class...> class P>
+struct mp_not_fn
+{
+  template <class... T>
+  using fn = mp_not<mp_invoke_q<mp_quote<P>, T...>>;
+};
+
+template <class Q>
+using mp_not_fn_q = mp_not_fn<Q::template fn>;
+
+} // namespace mp11
+} // namespace boost
+
+#endif // #ifndef BOOST_MP11_UTILITY_HPP_INCLUDED

--- a/include/foxy/detail/mp11/utility.hpp
+++ b/include/foxy/detail/mp11/utility.hpp
@@ -272,7 +272,7 @@ using mp_invoke_q = typename Q::template fn<T...>;
 
 // old name for mp_invoke_q retained for compatibility, but deprecated
 template <class Q, class... T>
-using mp_invoke BOOST_MP11_DEPRECATED("please use mp_invoke_q") = mp_invoke_q<Q, T...>;
+using mp_invoke = mp_invoke_q<Q, T...>;
 
 // mp_not_fn<P>
 template <template <class...> class P>

--- a/include/foxy/detail/tunnel.hpp
+++ b/include/foxy/detail/tunnel.hpp
@@ -184,14 +184,10 @@ tunnel_op<TunnelHandler>::operator()(boost::system::error_code ec,
       s.response.emplace(std::piecewise_construct, std::make_tuple(get_allocator()),
                          std::make_tuple(get_allocator()));
 
-      std::cout << "reading in client header...\n";
-
       BOOST_ASIO_CORO_YIELD
       s.server.async_read_header(*s.parser, std::move(*this));
 
       if (ec) { goto upcall; }
-
-      std::cout << "parsing URI now:" << s.parser->get().target() << "\n";
 
       s.uri_parts = foxy::parse_uri(s.parser->get().target());
 
@@ -201,8 +197,6 @@ tunnel_op<TunnelHandler>::operator()(boost::system::error_code ec,
       s.is_http      = s.uri_parts.is_http();
 
       if (s.is_connect && s.is_authority && !s.parser->keep_alive()) {
-        std::cout << "sending error response...\n";
-
         s.close_tunnel = true;
 
         s.response->result(http::status::bad_request);
@@ -217,8 +211,6 @@ tunnel_op<TunnelHandler>::operator()(boost::system::error_code ec,
       }
 
       if ((s.is_connect && s.is_authority) || (s.is_absolute && s.is_http)) {
-        std::cout << "connecting to: \n" << s.uri_parts.host() << "\n\n";
-
         BOOST_ASIO_CORO_YIELD
         {
           auto const scheme =
@@ -248,8 +240,6 @@ tunnel_op<TunnelHandler>::operator()(boost::system::error_code ec,
         }
 
       } else {
-        std::cout << "sending malformed response message\n";
-
         s.response->result(http::status::bad_request);
         s.response->body() =
           "Malformed client request. Use either CONNECT <authority-uri> or <verb> <absolute-uri>";
@@ -297,8 +287,6 @@ tunnel_op<TunnelHandler>::operator()(boost::system::error_code ec,
         s.close_tunnel = true;
         break;
       }
-
-      std::cout << "going to write back the tunnel response now\n";
 
       s.response->result(http::status::ok);
 

--- a/include/foxy/detail/variant2/variant.hpp
+++ b/include/foxy/detail/variant2/variant.hpp
@@ -1,0 +1,2243 @@
+// snapshot of commit:
+// https://github.com/pdimov/variant2/blob/30d974d0fc447b627cf29d50268136d1d6460ff3/include/boost/variant2/variant.hpp
+//
+
+#ifndef BOOST_VARIANT2_VARIANT_HPP_INCLUDED
+#define BOOST_VARIANT2_VARIANT_HPP_INCLUDED
+
+// Copyright 2017, 2018 Peter Dimov.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+#if defined(_MSC_VER) && _MSC_VER < 1910
+#pragma warning(push)
+#pragma warning(disable : 4521 4522) // multiple copy operators
+#endif
+
+#include <foxy/detail/mp11/detail/config.hpp>
+#include <foxy/detail/mp11/function.hpp>
+#include <foxy/detail/mp11/utility.hpp>
+
+#ifndef BOOST_MP11_HPP_INCLUDED
+#include <boost/mp11.hpp>
+#endif
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+#include <cstddef>
+#include <type_traits>
+#include <exception>
+#include <cassert>
+#include <initializer_list>
+#include <utility>
+
+//
+
+namespace boost
+{
+namespace variant2
+{
+// bad_variant_access
+
+class bad_variant_access : public std::exception {
+public:
+  bad_variant_access() noexcept {}
+
+  char const*
+  what() const noexcept
+  {
+    return "bad_variant_access";
+  }
+};
+
+// monostate
+
+struct monostate
+{
+};
+
+constexpr bool operator<(monostate, monostate) noexcept { return false; }
+constexpr bool operator>(monostate, monostate) noexcept { return false; }
+constexpr bool operator<=(monostate, monostate) noexcept { return true; }
+constexpr bool operator>=(monostate, monostate) noexcept { return true; }
+constexpr bool operator==(monostate, monostate) noexcept { return true; }
+constexpr bool operator!=(monostate, monostate) noexcept { return false; }
+
+// variant forward declaration
+
+template <class... T>
+class variant;
+
+// variant_size
+
+template <class T>
+struct variant_size
+{
+};
+
+template <class T>
+struct variant_size<T const> : variant_size<T>
+{
+};
+
+template <class T>
+struct variant_size<T volatile> : variant_size<T>
+{
+};
+
+template <class T>
+struct variant_size<T const volatile> : variant_size<T>
+{
+};
+
+template <class T>
+struct variant_size<T&> : variant_size<T>
+{
+};
+
+template <class T>
+struct variant_size<T&&> : variant_size<T>
+{
+};
+
+#if !defined(BOOST_NO_CXX14_VARIABLE_TEMPLATES)
+
+template <class T> /*inline*/ constexpr std::size_t variant_size_v = variant_size<T>::value;
+
+#endif
+
+template <class... T>
+struct variant_size<variant<T...>> : mp11::mp_size<variant<T...>>
+{
+};
+
+// variant_alternative
+
+template <std::size_t I, class T>
+struct variant_alternative;
+
+template <std::size_t I, class T>
+using variant_alternative_t = typename variant_alternative<I, T>::type;
+
+#if BOOST_WORKAROUND(BOOST_GCC, < 40900)
+
+namespace detail
+{
+template <std::size_t I, class T, bool E>
+struct variant_alternative_impl
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...>, true>
+{
+  using type = mp11::mp_at_c<variant<T...>, I>;
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...> const, true>
+  : std::add_const<mp11::mp_at_c<variant<T...>, I>>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...> volatile, true>
+  : std::add_volatile<mp11::mp_at_c<variant<T...>, I>>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...> const volatile, true>
+  : std::add_cv<mp11::mp_at_c<variant<T...>, I>>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...>&, true>
+  : std::add_lvalue_reference<mp11::mp_at_c<variant<T...>, I>>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...> const&, true>
+  : std::add_lvalue_reference<mp11::mp_at_c<variant<T...>, I> const>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...> volatile&, true>
+  : std::add_lvalue_reference<mp11::mp_at_c<variant<T...>, I> volatile>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...> const volatile&, true>
+  : std::add_lvalue_reference<mp11::mp_at_c<variant<T...>, I> const volatile>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...>&&, true>
+  : std::add_rvalue_reference<mp11::mp_at_c<variant<T...>, I>>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...> const&&, true>
+  : std::add_rvalue_reference<mp11::mp_at_c<variant<T...>, I> const>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...> volatile&&, true>
+  : std::add_rvalue_reference<mp11::mp_at_c<variant<T...>, I> volatile>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative_impl<I, variant<T...> const volatile&&, true>
+  : std::add_rvalue_reference<mp11::mp_at_c<variant<T...>, I> const volatile>
+{
+};
+
+} // namespace detail
+
+template <std::size_t I, class T>
+struct variant_alternative
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...>>
+  : public detail::variant_alternative_impl<I, variant<T...>, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...> const>
+  : public detail::variant_alternative_impl<I, variant<T...> const, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...> volatile>
+  : public detail::variant_alternative_impl<I, variant<T...> volatile, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...> const volatile>
+  : public detail::variant_alternative_impl<I, variant<T...> const volatile, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...>&>
+  : public detail::variant_alternative_impl<I, variant<T...>&, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...> const&>
+  : public detail::variant_alternative_impl<I, variant<T...> const&, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...> volatile&>
+  : public detail::variant_alternative_impl<I, variant<T...> volatile&, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...> const volatile&>
+  : public detail::variant_alternative_impl<I, variant<T...> const volatile&, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...>&&>
+  : public detail::variant_alternative_impl<I, variant<T...>&&, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...> const&&>
+  : public detail::variant_alternative_impl<I, variant<T...> const&&, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...> volatile&&>
+  : public detail::variant_alternative_impl<I, variant<T...> volatile&&, (I < sizeof...(T))>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...> const volatile&&>
+  : public detail::variant_alternative_impl<I, variant<T...> const volatile&&, (I < sizeof...(T))>
+{
+};
+
+#else
+
+namespace detail
+{
+template <class I, class T, class Q>
+using var_alt_impl = mp11::mp_invoke_q<Q, variant_alternative_t<I::value, T>>;
+
+} // namespace detail
+
+template <std::size_t I, class T>
+struct variant_alternative
+{
+};
+
+template <std::size_t I, class T>
+struct variant_alternative<I, T const>
+  : mp11::
+      mp_defer<detail::var_alt_impl, mp11::mp_size_t<I>, T, mp11::mp_quote_trait<std::add_const>>
+{
+};
+
+template <std::size_t I, class T>
+struct variant_alternative<I, T volatile>
+  : mp11::
+      mp_defer<detail::var_alt_impl, mp11::mp_size_t<I>, T, mp11::mp_quote_trait<std::add_volatile>>
+{
+};
+
+template <std::size_t I, class T>
+struct variant_alternative<I, T const volatile>
+  : mp11::mp_defer<detail::var_alt_impl, mp11::mp_size_t<I>, T, mp11::mp_quote_trait<std::add_cv>>
+{
+};
+
+template <std::size_t I, class T>
+struct variant_alternative<I, T&> : mp11::mp_defer<detail::var_alt_impl,
+                                                   mp11::mp_size_t<I>,
+                                                   T,
+                                                   mp11::mp_quote_trait<std::add_lvalue_reference>>
+{
+};
+
+template <std::size_t I, class T>
+struct variant_alternative<I, T&&> : mp11::mp_defer<detail::var_alt_impl,
+                                                    mp11::mp_size_t<I>,
+                                                    T,
+                                                    mp11::mp_quote_trait<std::add_rvalue_reference>>
+{
+};
+
+template <std::size_t I, class... T>
+struct variant_alternative<I, variant<T...>>
+  : mp11::mp_defer<mp11::mp_at, variant<T...>, mp11::mp_size_t<I>>
+{
+};
+
+#endif
+
+// holds_alternative
+
+template <class U, class... T>
+constexpr bool
+holds_alternative(variant<T...> const& v) noexcept
+{
+  static_assert(mp11::mp_count<variant<T...>, U>::value == 1,
+                "The type must occur exactly once in the list of variant alternatives");
+  return v.index() == mp11::mp_find<variant<T...>, U>::value;
+}
+
+// get (index)
+
+template <std::size_t I, class... T>
+constexpr variant_alternative_t<I, variant<T...>>&
+get(variant<T...>& v)
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+  return (void) (v.index() != I ? throw bad_variant_access() : 0),
+         v._get_impl(mp11::mp_size_t<I>());
+}
+
+template <std::size_t I, class... T>
+constexpr variant_alternative_t<I, variant<T...>>&&
+get(variant<T...>&& v)
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1920)
+
+  return (void) (v.index() != I ? throw bad_variant_access() : 0),
+         std::move(v._get_impl(mp11::mp_size_t<I>()));
+
+#else
+
+  if (v.index() != I) throw bad_variant_access();
+  return std::move(v._get_impl(mp11::mp_size_t<I>()));
+
+#endif
+}
+
+template <std::size_t I, class... T>
+constexpr variant_alternative_t<I, variant<T...>> const&
+get(variant<T...> const& v)
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+  return (void) (v.index() != I ? throw bad_variant_access() : 0),
+         v._get_impl(mp11::mp_size_t<I>());
+}
+
+template <std::size_t I, class... T>
+constexpr variant_alternative_t<I, variant<T...>> const&&
+get(variant<T...> const&& v)
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1920)
+
+  return (void) (v.index() != I ? throw bad_variant_access() : 0),
+         std::move(v._get_impl(mp11::mp_size_t<I>()));
+
+#else
+
+  if (v.index() != I) throw bad_variant_access();
+  return std::move(v._get_impl(mp11::mp_size_t<I>()));
+
+#endif
+}
+
+// detail::unsafe_get (for visit)
+
+namespace detail
+{
+template <std::size_t I, class... T>
+constexpr variant_alternative_t<I, variant<T...>>&
+unsafe_get(variant<T...>& v)
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+  return v._get_impl(mp11::mp_size_t<I>());
+}
+
+template <std::size_t I, class... T>
+constexpr variant_alternative_t<I, variant<T...>>&&
+unsafe_get(variant<T...>&& v)
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+  return std::move(v._get_impl(mp11::mp_size_t<I>()));
+}
+
+template <std::size_t I, class... T>
+constexpr variant_alternative_t<I, variant<T...>> const&
+unsafe_get(variant<T...> const& v)
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+  return v._get_impl(mp11::mp_size_t<I>());
+}
+
+template <std::size_t I, class... T>
+constexpr variant_alternative_t<I, variant<T...>> const&&
+unsafe_get(variant<T...> const&& v)
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+  return std::move(v._get_impl(mp11::mp_size_t<I>()));
+}
+
+} // namespace detail
+
+// get (type)
+
+template <class U, class... T>
+constexpr U&
+get(variant<T...>& v)
+{
+  static_assert(mp11::mp_count<variant<T...>, U>::value == 1,
+                "The type must occur exactly once in the list of variant alternatives");
+
+  using I = mp11::mp_find<variant<T...>, U>;
+
+  return (void) (v.index() != I::value ? throw bad_variant_access() : 0), v._get_impl(I());
+}
+
+template <class U, class... T>
+constexpr U&&
+get(variant<T...>&& v)
+{
+  static_assert(mp11::mp_count<variant<T...>, U>::value == 1,
+                "The type must occur exactly once in the list of variant alternatives");
+
+  using I = mp11::mp_find<variant<T...>, U>;
+
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1920)
+
+  return (void) (v.index() != I::value ? throw bad_variant_access() : 0),
+         std::move(v._get_impl(I()));
+
+#else
+
+  if (v.index() != I::value) throw bad_variant_access();
+  return std::move(v._get_impl(I()));
+
+#endif
+}
+
+template <class U, class... T>
+constexpr U const&
+get(variant<T...> const& v)
+{
+  static_assert(mp11::mp_count<variant<T...>, U>::value == 1,
+                "The type must occur exactly once in the list of variant alternatives");
+
+  using I = mp11::mp_find<variant<T...>, U>;
+
+  return (void) (v.index() != I::value ? throw bad_variant_access() : 0), v._get_impl(I());
+}
+
+template <class U, class... T>
+constexpr U const&&
+get(variant<T...> const&& v)
+{
+  static_assert(mp11::mp_count<variant<T...>, U>::value == 1,
+                "The type must occur exactly once in the list of variant alternatives");
+
+  using I = mp11::mp_find<variant<T...>, U>;
+
+#if !BOOST_WORKAROUND(BOOST_MSVC, < 1920)
+
+  return (void) (v.index() != I::value ? throw bad_variant_access() : 0),
+         std::move(v._get_impl(I()));
+
+#else
+
+  if (v.index() != I::value) throw bad_variant_access();
+  return std::move(v._get_impl(I()));
+
+#endif
+}
+
+// get_if
+
+template <std::size_t I, class... T>
+constexpr typename std::add_pointer<variant_alternative_t<I, variant<T...>>>::type
+get_if(variant<T...>* v) noexcept
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+  return v && v->index() == I ? &v->_get_impl(mp11::mp_size_t<I>()) : 0;
+}
+
+template <std::size_t I, class... T>
+constexpr typename std::add_pointer<const variant_alternative_t<I, variant<T...>>>::type
+get_if(variant<T...> const* v) noexcept
+{
+  static_assert(I < sizeof...(T), "Index out of bounds");
+  return v && v->index() == I ? &v->_get_impl(mp11::mp_size_t<I>()) : 0;
+}
+
+template <class U, class... T>
+constexpr typename std::add_pointer<U>::type
+get_if(variant<T...>* v) noexcept
+{
+  static_assert(mp11::mp_count<variant<T...>, U>::value == 1,
+                "The type must occur exactly once in the list of variant alternatives");
+
+  using I = mp11::mp_find<variant<T...>, U>;
+
+  return v && v->index() == I::value ? &v->_get_impl(I()) : 0;
+}
+
+template <class U, class... T>
+constexpr typename std::add_pointer<U const>::type
+get_if(variant<T...> const* v) noexcept
+{
+  static_assert(mp11::mp_count<variant<T...>, U>::value == 1,
+                "The type must occur exactly once in the list of variant alternatives");
+
+  using I = mp11::mp_find<variant<T...>, U>;
+
+  return v && v->index() == I::value ? &v->_get_impl(I()) : 0;
+}
+
+//
+
+namespace detail
+{
+// trivially_*
+
+#if defined(BOOST_LIBSTDCXX_VERSION) && BOOST_LIBSTDCXX_VERSION < 50000
+
+template <class T>
+struct is_trivially_copy_constructible : mp11::mp_bool<std::is_copy_constructible<T>::value &&
+                                                       std::has_trivial_copy_constructor<T>::value>
+{
+};
+
+template <class T>
+struct is_trivially_copy_assignable
+  : mp11::mp_bool<std::is_copy_assignable<T>::value && std::has_trivial_copy_assign<T>::value>
+{
+};
+
+template <class T>
+struct is_trivially_move_constructible
+  : mp11::mp_bool<std::is_move_constructible<T>::value && std::is_trivial<T>::value>
+{
+};
+
+template <class T>
+struct is_trivially_move_assignable
+  : mp11::mp_bool<std::is_move_assignable<T>::value && std::is_trivial<T>::value>
+{
+};
+
+#else
+
+using std::is_trivially_copy_constructible;
+using std::is_trivially_copy_assignable;
+using std::is_trivially_move_constructible;
+using std::is_trivially_move_assignable;
+
+#endif
+
+// variant_storage
+
+template <class D, class... T>
+union variant_storage_impl;
+
+template <class... T>
+using variant_storage =
+  variant_storage_impl<mp11::mp_all<std::is_trivially_destructible<T>...>, T...>;
+
+template <class D>
+union variant_storage_impl<D>
+{
+};
+
+// not all trivially destructible
+template <class T1, class... T>
+union variant_storage_impl<mp11::mp_false, T1, T...>
+{
+  T1                    first_;
+  variant_storage<T...> rest_;
+
+  template <class... A>
+  constexpr explicit variant_storage_impl(mp11::mp_size_t<0>, A&&... a)
+    : first_(std::forward<A>(a)...)
+  {
+  }
+
+  template <std::size_t I, class... A>
+  constexpr explicit variant_storage_impl(mp11::mp_size_t<I>, A&&... a)
+    : rest_(mp11::mp_size_t<I - 1>(), std::forward<A>(a)...)
+  {
+  }
+
+  ~variant_storage_impl() {}
+
+  template <class... A>
+  void emplace(mp11::mp_size_t<0>, A&&... a)
+  {
+    ::new (&first_) T1(std::forward<A>(a)...);
+  }
+
+  template <std::size_t I, class... A>
+  void
+  emplace(mp11::mp_size_t<I>, A&&... a)
+  {
+    rest_.emplace(mp11::mp_size_t<I - 1>(), std::forward<A>(a)...);
+  }
+
+  BOOST_CXX14_CONSTEXPR T1& get(mp11::mp_size_t<0>) noexcept { return first_; }
+  constexpr T1 const&       get(mp11::mp_size_t<0>) const noexcept { return first_; }
+
+  template <std::size_t I>
+  BOOST_CXX14_CONSTEXPR mp11::mp_at_c<mp11::mp_list<T...>, I - 1>& get(mp11::mp_size_t<I>) noexcept
+  {
+    return rest_.get(mp11::mp_size_t<I - 1>());
+  }
+  template <std::size_t I>
+  constexpr mp11::mp_at_c<mp11::mp_list<T...>, I - 1> const& get(mp11::mp_size_t<I>) const noexcept
+  {
+    return rest_.get(mp11::mp_size_t<I - 1>());
+  }
+};
+
+// all trivially destructible
+template <class T1, class... T>
+union variant_storage_impl<mp11::mp_true, T1, T...>
+{
+  T1                    first_;
+  variant_storage<T...> rest_;
+
+  template <class... A>
+  constexpr explicit variant_storage_impl(mp11::mp_size_t<0>, A&&... a)
+    : first_(std::forward<A>(a)...)
+  {
+  }
+
+  template <std::size_t I, class... A>
+  constexpr explicit variant_storage_impl(mp11::mp_size_t<I>, A&&... a)
+    : rest_(mp11::mp_size_t<I - 1>(), std::forward<A>(a)...)
+  {
+  }
+
+  template <class... A>
+  void emplace_impl(mp11::mp_false, mp11::mp_size_t<0>, A&&... a)
+  {
+    ::new (&first_) T1(std::forward<A>(a)...);
+  }
+
+  template <std::size_t I, class... A>
+  BOOST_CXX14_CONSTEXPR void
+  emplace_impl(mp11::mp_false, mp11::mp_size_t<I>, A&&... a)
+  {
+    rest_.emplace(mp11::mp_size_t<I - 1>(), std::forward<A>(a)...);
+  }
+
+  template <std::size_t I, class... A>
+  BOOST_CXX14_CONSTEXPR void
+  emplace_impl(mp11::mp_true, mp11::mp_size_t<I>, A&&... a)
+  {
+    *this = variant_storage_impl(mp11::mp_size_t<I>(), std::forward<A>(a)...);
+  }
+
+  template <std::size_t I, class... A>
+  BOOST_CXX14_CONSTEXPR void
+  emplace(mp11::mp_size_t<I>, A&&... a)
+  {
+    this->emplace_impl(mp11::mp_all<detail::is_trivially_move_assignable<T1>,
+                                    detail::is_trivially_move_assignable<T>...>(),
+                       mp11::mp_size_t<I>(), std::forward<A>(a)...);
+  }
+
+  BOOST_CXX14_CONSTEXPR T1& get(mp11::mp_size_t<0>) noexcept { return first_; }
+  constexpr T1 const&       get(mp11::mp_size_t<0>) const noexcept { return first_; }
+
+  template <std::size_t I>
+  BOOST_CXX14_CONSTEXPR mp11::mp_at_c<mp11::mp_list<T...>, I - 1>& get(mp11::mp_size_t<I>) noexcept
+  {
+    return rest_.get(mp11::mp_size_t<I - 1>());
+  }
+  template <std::size_t I>
+  constexpr mp11::mp_at_c<mp11::mp_list<T...>, I - 1> const& get(mp11::mp_size_t<I>) const noexcept
+  {
+    return rest_.get(mp11::mp_size_t<I - 1>());
+  }
+};
+
+// resolve_overload_*
+
+template <class... T>
+struct overload;
+
+template <>
+struct overload<>
+{
+  void
+  operator()() const;
+};
+
+template <class T1, class... T>
+struct overload<T1, T...> : overload<T...>
+{
+  using overload<T...>::operator();
+  mp11::mp_identity<T1> operator()(T1) const;
+};
+
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1920)
+
+template <class U, class... T>
+using resolve_overload_type_ = decltype(overload<T...>()(std::declval<U>()));
+
+template <class U, class... T>
+struct resolve_overload_type_impl : mp11::mp_defer<resolve_overload_type_, U, T...>
+{
+};
+
+template <class U, class... T>
+using resolve_overload_type = typename resolve_overload_type_impl<U, T...>::type::type;
+
+#else
+
+template <class U, class... T>
+using resolve_overload_type = typename decltype(overload<T...>()(std::declval<U>()))::type;
+
+#endif
+
+template <class U, class... T>
+using resolve_overload_index = mp11::mp_find<mp11::mp_list<T...>, resolve_overload_type<U, T...>>;
+
+// variant_base
+
+template <class... T>
+using can_be_valueless =
+  mp11::mp_any<std::is_same<T, monostate>..., std::is_nothrow_default_constructible<T>...>;
+template <class... T>
+using valueless_index =
+  mp11::mp_if<mp11::mp_contains<mp11::mp_list<T...>, monostate>,
+              mp11::mp_find<mp11::mp_list<T...>, monostate>,
+              mp11::mp_find_if<mp11::mp_list<T...>, std::is_nothrow_default_constructible>>;
+
+template <bool is_trivially_destructible, bool is_single_buffered, class... T>
+struct variant_base_impl; // trivially destructible, single buffered
+template <class... T>
+using variant_base =
+  variant_base_impl<mp11::mp_all<std::is_trivially_destructible<T>...>::value,
+                    mp11::mp_any<mp11::mp_all<std::is_nothrow_move_constructible<T>...>,
+                                 can_be_valueless<T...>>::value,
+                    T...>;
+
+struct none
+{
+};
+
+// trivially destructible, single buffered
+template <class... T>
+struct variant_base_impl<true, true, T...>
+{
+  int                         ix_;
+  variant_storage<none, T...> st1_;
+
+  constexpr variant_base_impl()
+    : ix_(0)
+    , st1_(mp11::mp_size_t<0>())
+  {
+  }
+
+  template <class I, class... A>
+  constexpr explicit variant_base_impl(I, A&&... a)
+    : ix_(I::value + 1)
+    , st1_(mp11::mp_size_t<I::value + 1>(), std::forward<A>(a)...)
+  {
+  }
+
+  // requires: ix_ == 0
+  template <class I, class... A>
+  void
+  _replace(I, A&&... a)
+  {
+    ::new (&st1_)
+      variant_storage<none, T...>(mp11::mp_size_t<I::value + 1>(), std::forward<A>(a)...);
+    ix_ = I::value + 1;
+  }
+
+  constexpr std::size_t
+  index() const noexcept
+  {
+    return ix_ - 1;
+  }
+
+  template <std::size_t I>
+  BOOST_CXX14_CONSTEXPR mp11::mp_at_c<variant<T...>, I>& _get_impl(mp11::mp_size_t<I>) noexcept
+  {
+    size_t const J = I + 1;
+
+    assert(ix_ == J);
+
+    return st1_.get(mp11::mp_size_t<J>());
+  }
+
+  template <std::size_t I>
+  constexpr mp11::mp_at_c<variant<T...>, I> const& _get_impl(mp11::mp_size_t<I>) const noexcept
+  {
+    // size_t const J = I+1;
+    // assert( ix_ == I+1 );
+
+    return st1_.get(mp11::mp_size_t<I + 1>());
+  }
+
+  template <std::size_t J, class U, bool B, class... A>
+  BOOST_CXX14_CONSTEXPR void
+  emplace_impl(mp11::mp_true, mp11::mp_bool<B>, A&&... a)
+  {
+    st1_.emplace(mp11::mp_size_t<J>(), std::forward<A>(a)...);
+    ix_ = J;
+  }
+
+  template <std::size_t J, class U, class... A>
+  BOOST_CXX14_CONSTEXPR void
+  emplace_impl(mp11::mp_false, mp11::mp_true, A&&... a)
+  {
+    U tmp(std::forward<A>(a)...);
+
+    st1_.emplace(mp11::mp_size_t<J>(), std::move(tmp));
+    ix_ = J;
+  }
+
+  template <std::size_t J, class U, class... A>
+  void
+  emplace_impl(mp11::mp_false, mp11::mp_false, A&&... a)
+  {
+    if (can_be_valueless<T...>::value) {
+      std::size_t const K = valueless_index<T...>::value;
+
+      assert(K < sizeof...(T));
+
+      try {
+        st1_.emplace(mp11::mp_size_t<J>(), std::forward<A>(a)...);
+        ix_ = J;
+      }
+      catch (...) {
+        st1_.emplace(mp11::mp_size_t<K + 1>());
+        ix_ = K + 1;
+
+        throw;
+      }
+    } else {
+      assert(std::is_nothrow_move_constructible<U>::value);
+
+      U tmp(std::forward<A>(a)...);
+
+      st1_.emplace(mp11::mp_size_t<J>(), std::move(tmp));
+      ix_ = J;
+    }
+  }
+
+  template <std::size_t I, class... A>
+  BOOST_CXX14_CONSTEXPR void
+  emplace(A&&... a)
+  {
+    std::size_t const J = I + 1;
+    using U             = mp11::mp_at_c<variant<T...>, I>;
+
+    this->emplace_impl<J, U>(std::is_nothrow_constructible<U, A&&...>(),
+                             mp11::mp_all<detail::is_trivially_move_constructible<U>,
+                                          detail::is_trivially_move_assignable<T>...>(),
+                             std::forward<A>(a)...);
+  }
+};
+
+// trivially destructible, double buffered
+template <class... T>
+struct variant_base_impl<true, false, T...>
+{
+  int                         ix_;
+  variant_storage<none, T...> st1_;
+  variant_storage<none, T...> st2_;
+
+  constexpr variant_base_impl()
+    : ix_(0)
+    , st1_(mp11::mp_size_t<0>())
+    , st2_(mp11::mp_size_t<0>())
+  {
+  }
+
+  template <class I, class... A>
+  constexpr explicit variant_base_impl(I, A&&... a)
+    : ix_(I::value + 1)
+    , st1_(mp11::mp_size_t<I::value + 1>(), std::forward<A>(a)...)
+    , st2_(mp11::mp_size_t<0>())
+  {
+  }
+
+  // requires: ix_ == 0
+  template <class I, class... A>
+  void
+  _replace(I, A&&... a)
+  {
+    ::new (&st1_)
+      variant_storage<none, T...>(mp11::mp_size_t<I::value + 1>(), std::forward<A>(a)...);
+    ix_ = I::value + 1;
+  }
+
+  constexpr std::size_t
+  index() const noexcept
+  {
+    return ix_ >= 0 ? ix_ - 1 : -ix_ - 1;
+  }
+
+  template <std::size_t I>
+  BOOST_CXX14_CONSTEXPR mp11::mp_at_c<variant<T...>, I>& _get_impl(mp11::mp_size_t<I>) noexcept
+  {
+    size_t const J = I + 1;
+
+    assert(ix_ == J || -ix_ == J);
+
+    constexpr mp11::mp_size_t<J> j{};
+    return ix_ >= 0 ? st1_.get(j) : st2_.get(j);
+  }
+
+  template <std::size_t I>
+  constexpr mp11::mp_at_c<variant<T...>, I> const& _get_impl(mp11::mp_size_t<I>) const noexcept
+  {
+    // size_t const J = I+1;
+    // assert( ix_ == J || -ix_ == J );
+    // constexpr mp_size_t<J> j{};
+
+    return ix_ >= 0 ? st1_.get(mp11::mp_size_t<I + 1>()) : st2_.get(mp11::mp_size_t<I + 1>());
+  }
+
+  template <std::size_t I, class... A>
+  BOOST_CXX14_CONSTEXPR void
+  emplace(A&&... a)
+  {
+    size_t const J = I + 1;
+
+    if (ix_ >= 0) {
+      st2_.emplace(mp11::mp_size_t<J>(), std::forward<A>(a)...);
+      ix_ = -static_cast<int>(J);
+    } else {
+      st1_.emplace(mp11::mp_size_t<J>(), std::forward<A>(a)...);
+      ix_ = J;
+    }
+  }
+};
+
+// not trivially destructible, single buffered
+template <class... T>
+struct variant_base_impl<false, true, T...>
+{
+  int                         ix_;
+  variant_storage<none, T...> st1_;
+
+  constexpr variant_base_impl()
+    : ix_(0)
+    , st1_(mp11::mp_size_t<0>())
+  {
+  }
+
+  template <class I, class... A>
+  constexpr explicit variant_base_impl(I, A&&... a)
+    : ix_(I::value + 1)
+    , st1_(mp11::mp_size_t<I::value + 1>(), std::forward<A>(a)...)
+  {
+  }
+
+  // requires: ix_ == 0
+  template <class I, class... A>
+  void
+  _replace(I, A&&... a)
+  {
+    ::new (&st1_)
+      variant_storage<none, T...>(mp11::mp_size_t<I::value + 1>(), std::forward<A>(a)...);
+    ix_ = I::value + 1;
+  }
+
+  //[&]( auto I ){
+  //    using U = mp_at_c<mp_list<none, T...>, I>;
+  //    st1_.get( I ).~U();
+  //}
+
+  struct _destroy_L1
+  {
+    variant_base_impl* this_;
+
+    template <class I>
+    void operator()(I) const noexcept
+    {
+      using U = mp11::mp_at<mp11::mp_list<none, T...>, I>;
+      this_->st1_.get(I()).~U();
+    }
+  };
+
+  void
+  _destroy() noexcept
+  {
+    if (ix_ > 0) { mp11::mp_with_index<1 + sizeof...(T)>(ix_, _destroy_L1{this}); }
+  }
+
+  ~variant_base_impl() noexcept { _destroy(); }
+
+  constexpr std::size_t
+  index() const noexcept
+  {
+    return ix_ - 1;
+  }
+
+  template <std::size_t I>
+  BOOST_CXX14_CONSTEXPR mp11::mp_at_c<variant<T...>, I>& _get_impl(mp11::mp_size_t<I>) noexcept
+  {
+    size_t const J = I + 1;
+
+    assert(ix_ == J);
+
+    return st1_.get(mp11::mp_size_t<J>());
+  }
+
+  template <std::size_t I>
+  constexpr mp11::mp_at_c<variant<T...>, I> const& _get_impl(mp11::mp_size_t<I>) const noexcept
+  {
+    // size_t const J = I+1;
+    // assert( ix_ == J );
+
+    return st1_.get(mp11::mp_size_t<I + 1>());
+  }
+
+  template <std::size_t I, class... A>
+  void
+  emplace(A&&... a)
+  {
+    size_t const J = I + 1;
+
+    using U = mp11::mp_at_c<variant<T...>, I>;
+
+    if (std::is_nothrow_constructible<U, A...>::value) {
+      _destroy();
+
+      st1_.emplace(mp11::mp_size_t<J>(), std::forward<A>(a)...);
+      ix_ = J;
+    } else if (can_be_valueless<T...>::value) {
+      std::size_t const K = valueless_index<T...>::value;
+
+      assert(K < sizeof...(T));
+
+      _destroy();
+
+      try {
+        st1_.emplace(mp11::mp_size_t<J>(), std::forward<A>(a)...);
+        ix_ = J;
+      }
+      catch (...) {
+        st1_.emplace(mp11::mp_size_t<K + 1>());
+        ix_ = K + 1;
+
+        throw;
+      }
+    } else {
+      assert(std::is_nothrow_move_constructible<U>::value);
+
+      U tmp(std::forward<A>(a)...);
+
+      _destroy();
+
+      st1_.emplace(mp11::mp_size_t<J>(), std::move(tmp));
+      ix_ = J;
+    }
+  }
+};
+
+// not trivially destructible, double buffered
+template <class... T>
+struct variant_base_impl<false, false, T...>
+{
+  int                         ix_;
+  variant_storage<none, T...> st1_;
+  variant_storage<none, T...> st2_;
+
+  constexpr variant_base_impl()
+    : ix_(0)
+    , st1_(mp11::mp_size_t<0>())
+    , st2_(mp11::mp_size_t<0>())
+  {
+  }
+
+  template <class I, class... A>
+  constexpr explicit variant_base_impl(I, A&&... a)
+    : ix_(I::value + 1)
+    , st1_(mp11::mp_size_t<I::value + 1>(), std::forward<A>(a)...)
+    , st2_(mp11::mp_size_t<0>())
+  {
+  }
+
+  // requires: ix_ == 0
+  template <class I, class... A>
+  void
+  _replace(I, A&&... a)
+  {
+    ::new (&st1_)
+      variant_storage<none, T...>(mp11::mp_size_t<I::value + 1>(), std::forward<A>(a)...);
+    ix_ = I::value + 1;
+  }
+
+  //[&]( auto I ){
+  //    using U = mp_at_c<mp_list<none, T...>, I>;
+  //    st1_.get( I ).~U();
+  //}
+
+  struct _destroy_L1
+  {
+    variant_base_impl* this_;
+
+    template <class I>
+    void operator()(I) const noexcept
+    {
+      using U = mp11::mp_at<mp11::mp_list<none, T...>, I>;
+      this_->st1_.get(I()).~U();
+    }
+  };
+
+  struct _destroy_L2
+  {
+    variant_base_impl* this_;
+
+    template <class I>
+    void operator()(I) const noexcept
+    {
+      using U = mp11::mp_at<mp11::mp_list<none, T...>, I>;
+      this_->st2_.get(I()).~U();
+    }
+  };
+
+  void
+  _destroy() noexcept
+  {
+    if (ix_ > 0) {
+      mp11::mp_with_index<1 + sizeof...(T)>(ix_, _destroy_L1{this});
+    } else if (ix_ < 0) {
+      mp11::mp_with_index<1 + sizeof...(T)>(-ix_, _destroy_L2{this});
+    }
+  }
+
+  ~variant_base_impl() noexcept { _destroy(); }
+
+  constexpr std::size_t
+  index() const noexcept
+  {
+    return ix_ >= 0 ? ix_ - 1 : -ix_ - 1;
+  }
+
+  template <std::size_t I>
+  BOOST_CXX14_CONSTEXPR mp11::mp_at_c<variant<T...>, I>& _get_impl(mp11::mp_size_t<I>) noexcept
+  {
+    size_t const J = I + 1;
+
+    assert(ix_ == J || -ix_ == J);
+
+    constexpr mp11::mp_size_t<J> j{};
+    return ix_ >= 0 ? st1_.get(j) : st2_.get(j);
+  }
+
+  template <std::size_t I>
+  constexpr mp11::mp_at_c<variant<T...>, I> const& _get_impl(mp11::mp_size_t<I>) const noexcept
+  {
+    // size_t const J = I+1;
+    // assert( ix_ == J || -ix_ == J );
+    // constexpr mp_size_t<J> j{};
+
+    return ix_ >= 0 ? st1_.get(mp11::mp_size_t<I + 1>()) : st2_.get(mp11::mp_size_t<I + 1>());
+  }
+
+  template <std::size_t I, class... A>
+  void
+  emplace(A&&... a)
+  {
+    size_t const J = I + 1;
+
+    if (ix_ >= 0) {
+      st2_.emplace(mp11::mp_size_t<J>(), std::forward<A>(a)...);
+      _destroy();
+
+      ix_ = -static_cast<int>(J);
+    } else {
+      st1_.emplace(mp11::mp_size_t<J>(), std::forward<A>(a)...);
+      _destroy();
+
+      ix_ = J;
+    }
+  }
+};
+
+} // namespace detail
+
+// in_place_type_t
+
+template <class T>
+struct in_place_type_t
+{
+};
+
+#if !defined(BOOST_NO_CXX14_VARIABLE_TEMPLATES)
+
+template <class T>
+constexpr in_place_type_t<T> in_place_type{};
+
+#endif
+
+namespace detail
+{
+template <class T>
+struct is_in_place_type : std::false_type
+{
+};
+template <class T>
+struct is_in_place_type<in_place_type_t<T>> : std::true_type
+{
+};
+
+} // namespace detail
+
+// in_place_index_t
+
+template <std::size_t I>
+struct in_place_index_t
+{
+};
+
+#if !defined(BOOST_NO_CXX14_VARIABLE_TEMPLATES)
+
+template <std::size_t I>
+constexpr in_place_index_t<I> in_place_index{};
+
+#endif
+
+namespace detail
+{
+template <class T>
+struct is_in_place_index : std::false_type
+{
+};
+template <std::size_t I>
+struct is_in_place_index<in_place_index_t<I>> : std::true_type
+{
+};
+
+} // namespace detail
+
+// is_nothrow_swappable
+
+namespace detail
+{
+namespace det2
+{
+using std::swap;
+
+template <class T>
+using is_swappable_impl = decltype(swap(std::declval<T&>(), std::declval<T&>()));
+
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1920)
+
+template <class T>
+struct is_nothrow_swappable_impl_
+{
+  static constexpr bool value = noexcept(swap(std::declval<T&>(), std::declval<T&>()));
+};
+
+template <class T>
+using is_nothrow_swappable_impl = mp11::mp_bool<is_nothrow_swappable_impl_<T>::value>;
+
+#else
+
+template <class T>
+using is_nothrow_swappable_impl =
+  typename std::enable_if<noexcept(swap(std::declval<T&>(), std::declval<T&>()))>::type;
+
+#endif
+
+} // namespace det2
+
+template <class T>
+struct is_swappable : mp11::mp_valid<det2::is_swappable_impl, T>
+{
+};
+
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1920)
+
+template <class T>
+struct is_nothrow_swappable
+  : mp11::
+      mp_eval_if<mp11::mp_not<is_swappable<T>>, mp11::mp_false, det2::is_nothrow_swappable_impl, T>
+{
+};
+
+#else
+
+template <class T>
+struct is_nothrow_swappable : mp11::mp_valid<det2::is_nothrow_swappable_impl, T>
+{
+};
+
+#endif
+
+} // namespace detail
+
+// variant
+
+template <class... T>
+class variant : private detail::variant_base<T...> {
+private:
+  using variant_base = detail::variant_base<T...>;
+
+private:
+  variant(variant const volatile& r) = delete;
+  variant&
+  operator=(variant const volatile& r) = delete;
+
+public:
+  // constructors
+
+  template <
+    class E1 = void,
+    class E2 = mp11::mp_if<std::is_default_constructible<mp11::mp_first<variant<T...>>>, E1>>
+  constexpr variant() noexcept(
+    std::is_nothrow_default_constructible<mp11::mp_first<variant<T...>>>::value)
+    : variant_base(mp11::mp_size_t<0>())
+  {
+  }
+
+  template <class E1 = void,
+            class E2 = mp11::mp_if<mp11::mp_all<detail::is_trivially_copy_constructible<T>...>, E1>>
+  constexpr variant(variant const& r) noexcept
+    : variant_base(static_cast<variant_base const&>(r))
+  {
+  }
+
+private:
+  struct L1
+  {
+    variant_base*  this_;
+    variant const& r;
+
+    template <class I>
+    void
+    operator()(I i) const
+    {
+      this_->_replace(i, r._get_impl(i));
+    }
+  };
+
+public:
+  template <
+    class E1 = void,
+    class E2 =
+      mp11::mp_if<mp11::mp_not<mp11::mp_all<detail::is_trivially_copy_constructible<T>...>>, E1>,
+    class E3 = mp11::mp_if<mp11::mp_all<std::is_copy_constructible<T>...>, E1>>
+  variant(variant const& r) noexcept(mp11::mp_all<std::is_nothrow_copy_constructible<T>...>::value)
+  {
+    mp11::mp_with_index<sizeof...(T)>(r.index(), L1{this, r});
+  }
+
+  template <class E1 = void,
+            class E2 = mp11::mp_if<mp11::mp_all<detail::is_trivially_move_constructible<T>...>, E1>>
+  constexpr variant(variant&& r) noexcept
+    : variant_base(static_cast<variant_base&&>(r))
+  {
+  }
+
+private:
+  struct L2
+  {
+    variant_base* this_;
+    variant&      r;
+
+    template <class I>
+    void
+    operator()(I i) const
+    {
+      this_->_replace(i, std::move(r._get_impl(i)));
+    }
+  };
+
+public:
+  template <
+    class E1 = void,
+    class E2 =
+      mp11::mp_if<mp11::mp_not<mp11::mp_all<detail::is_trivially_move_constructible<T>...>>, E1>,
+    class E3 = mp11::mp_if<mp11::mp_all<std::is_move_constructible<T>...>, E1>>
+  variant(variant&& r) noexcept(mp11::mp_all<std::is_nothrow_move_constructible<T>...>::value)
+  {
+    mp11::mp_with_index<sizeof...(T)>(r.index(), L2{this, r});
+  }
+
+  template <class U,
+            class Ud = typename std::decay<U>::type,
+            class E1 = typename std::enable_if<!std::is_same<Ud, variant>::value &&
+                                               !detail::is_in_place_index<Ud>::value &&
+                                               !detail::is_in_place_type<Ud>::value>::type,
+            class V  = detail::resolve_overload_type<U&&, T...>,
+            class E2 = typename std::enable_if<std::is_constructible<V, U>::value>::type>
+  constexpr variant(U&& u) noexcept(std::is_nothrow_constructible<V, U>::value)
+    : variant_base(detail::resolve_overload_index<U&&, T...>(), std::forward<U>(u))
+  {
+  }
+
+  template <class U,
+            class... A,
+            class I = mp11::mp_find<variant<T...>, U>,
+            class E = typename std::enable_if<std::is_constructible<U, A...>::value>::type>
+  constexpr explicit variant(in_place_type_t<U>, A&&... a)
+    : variant_base(I(), std::forward<A>(a)...)
+  {
+  }
+
+  template <class U,
+            class V,
+            class... A,
+            class I = mp11::mp_find<variant<T...>, U>,
+            class E = typename std::enable_if<
+              std::is_constructible<U, std::initializer_list<V>&, A...>::value>::type>
+  constexpr explicit variant(in_place_type_t<U>, std::initializer_list<V> il, A&&... a)
+    : variant_base(I(), il, std::forward<A>(a)...)
+  {
+  }
+
+  template <std::size_t I,
+            class... A,
+            class E = typename std::enable_if<
+              std::is_constructible<mp11::mp_at_c<variant<T...>, I>, A...>::value>::type>
+  constexpr explicit variant(in_place_index_t<I>, A&&... a)
+    : variant_base(mp11::mp_size_t<I>(), std::forward<A>(a)...)
+  {
+  }
+
+  template <std::size_t I,
+            class V,
+            class... A,
+            class E = typename std::enable_if<std::is_constructible<mp11::mp_at_c<variant<T...>, I>,
+                                                                    std::initializer_list<V>&,
+                                                                    A...>::value>::type>
+  constexpr explicit variant(in_place_index_t<I>, std::initializer_list<V> il, A&&... a)
+    : variant_base(mp11::mp_size_t<I>(), il, std::forward<A>(a)...)
+  {
+  }
+
+  // assignment
+  template <class E1 = void,
+            class E2 = mp11::mp_if<mp11::mp_all<std::is_trivially_destructible<T>...,
+                                                detail::is_trivially_copy_assignable<T>...>,
+                                   E1>>
+  BOOST_CXX14_CONSTEXPR variant&
+                        operator=(variant const& r) noexcept
+  {
+    static_cast<variant_base&>(*this) = static_cast<variant_base const&>(r);
+    return *this;
+  }
+
+private:
+  struct L3
+  {
+    variant*       this_;
+    variant const& r;
+
+    template <class I>
+    void
+    operator()(I i) const
+    {
+      if (this_->index() == i) {
+        this_->_get_impl(i) = r._get_impl(i);
+      } else {
+        this_->variant_base::template emplace<I::value>(r._get_impl(i));
+      }
+    }
+  };
+
+public:
+  template <
+    class E1 = void,
+    class E2 = mp11::mp_if<mp11::mp_not<mp11::mp_all<std::is_trivially_destructible<T>...,
+                                                     detail::is_trivially_copy_assignable<T>...>>,
+                           E1>,
+    class E3 = mp11::
+      mp_if<mp11::mp_all<std::is_copy_constructible<T>..., std::is_copy_assignable<T>...>, E1>>
+  BOOST_CXX14_CONSTEXPR variant&
+                        operator=(variant const& r) noexcept(mp11::mp_all<std::is_nothrow_copy_constructible<T>...,
+                                                    std::is_nothrow_copy_assignable<T>...>::value)
+  {
+    mp11::mp_with_index<sizeof...(T)>(r.index(), L3{this, r});
+    return *this;
+  }
+
+  template <class E1 = void,
+            class E2 = mp11::mp_if<mp11::mp_all<std::is_trivially_destructible<T>...,
+                                                detail::is_trivially_move_assignable<T>...>,
+                                   E1>>
+  BOOST_CXX14_CONSTEXPR variant&
+                        operator=(variant&& r) noexcept
+  {
+    static_cast<variant_base&>(*this) = static_cast<variant_base&&>(r);
+    return *this;
+  }
+
+private:
+  struct L4
+  {
+    variant* this_;
+    variant& r;
+
+    template <class I>
+    void
+    operator()(I i) const
+    {
+      if (this_->index() == i) {
+        this_->_get_impl(i) = std::move(r._get_impl(i));
+      } else {
+        this_->variant_base::template emplace<I::value>(std::move(r._get_impl(i)));
+      }
+    }
+  };
+
+public:
+  template <
+    class E1 = void,
+    class E2 = mp11::mp_if<mp11::mp_not<mp11::mp_all<std::is_trivially_destructible<T>...,
+                                                     detail::is_trivially_move_assignable<T>...>>,
+                           E1>,
+    class E3 = mp11::
+      mp_if<mp11::mp_all<std::is_move_constructible<T>..., std::is_move_assignable<T>...>, E1>>
+  variant&
+  operator=(variant&& r) noexcept(mp11::mp_all<std::is_nothrow_move_constructible<T>...,
+                                               std::is_nothrow_move_assignable<T>...>::value)
+  {
+    mp11::mp_with_index<sizeof...(T)>(r.index(), L4{this, r});
+    return *this;
+  }
+
+  template <class U,
+            class E1 = typename std::enable_if<
+              !std::is_same<typename std::decay<U>::type, variant>::value>::type,
+            class V  = detail::resolve_overload_type<U, T...>,
+            class E2 = typename std::enable_if<std::is_assignable<V&, U>::value &&
+                                               std::is_constructible<V, U>::value>::type>
+  BOOST_CXX14_CONSTEXPR variant&
+                        operator=(U&& u) noexcept(
+    std::is_nothrow_assignable<V&, U>::value&& std::is_nothrow_constructible<V, U>::value)
+  {
+    std::size_t const I = detail::resolve_overload_index<U, T...>::value;
+
+    if (index() == I) {
+      _get_impl(mp11::mp_size_t<I>()) = std::forward<U>(u);
+    } else {
+      this->template emplace<I>(std::forward<U>(u));
+    }
+
+    return *this;
+  }
+
+  // modifiers
+
+  template <class U,
+            class... A,
+            class E = typename std::enable_if<mp11::mp_count<variant<T...>, U>::value == 1 &&
+                                              std::is_constructible<U, A...>::value>::type>
+  BOOST_CXX14_CONSTEXPR U&
+                        emplace(A&&... a)
+  {
+    using I = mp11::mp_find<variant<T...>, U>;
+    variant_base::template emplace<I::value>(std::forward<A>(a)...);
+    return _get_impl(I());
+  }
+
+  template <class U,
+            class V,
+            class... A,
+            class E = typename std::enable_if<
+              mp11::mp_count<variant<T...>, U>::value == 1 &&
+              std::is_constructible<U, std::initializer_list<V>&, A...>::value>::type>
+  BOOST_CXX14_CONSTEXPR U&
+                        emplace(std::initializer_list<V> il, A&&... a)
+  {
+    using I = mp11::mp_find<variant<T...>, U>;
+    variant_base::template emplace<I::value>(il, std::forward<A>(a)...);
+    return _get_impl(I());
+  }
+
+  template <std::size_t I,
+            class... A,
+            class E = typename std::enable_if<
+              std::is_constructible<mp11::mp_at_c<variant<T...>, I>, A...>::value>::type>
+  BOOST_CXX14_CONSTEXPR variant_alternative_t<I, variant<T...>>&
+                        emplace(A&&... a)
+  {
+    variant_base::template emplace<I>(std::forward<A>(a)...);
+    return _get_impl(mp11::mp_size_t<I>());
+  }
+
+  template <std::size_t I,
+            class V,
+            class... A,
+            class E = typename std::enable_if<std::is_constructible<mp11::mp_at_c<variant<T...>, I>,
+                                                                    std::initializer_list<V>&,
+                                                                    A...>::value>::type>
+  BOOST_CXX14_CONSTEXPR variant_alternative_t<I, variant<T...>>&
+                        emplace(std::initializer_list<V> il, A&&... a)
+  {
+    variant_base::template emplace<I>(il, std::forward<A>(a)...);
+    return _get_impl(mp11::mp_size_t<I>());
+  }
+
+  // value status
+
+  using variant_base::index;
+
+  // swap
+
+private:
+  struct L5
+  {
+    variant* this_;
+    variant& r;
+
+    template <class I>
+    void
+    operator()(I i) const
+    {
+      using std::swap;
+      swap(this_->_get_impl(i), r._get_impl(i));
+    }
+  };
+
+public:
+  void
+  swap(variant& r) noexcept(mp11::mp_all<std::is_nothrow_move_constructible<T>...,
+                                         detail::is_nothrow_swappable<T>...>::value)
+  {
+    if (index() == r.index()) {
+      mp11::mp_with_index<sizeof...(T)>(index(), L5{this, r});
+    } else {
+      variant tmp(std::move(*this));
+      *this = std::move(r);
+      r     = std::move(tmp);
+    }
+  }
+
+  // private accessors
+
+  constexpr int
+  _real_index() const noexcept
+  {
+    return this->ix_;
+  }
+
+  using variant_base::_get_impl;
+
+  // converting constructors (extension)
+
+private:
+  template <class... U>
+  struct L6
+  {
+    variant_base*        this_;
+    variant<U...> const& r;
+
+    template <class I>
+    void
+    operator()(I i) const
+    {
+      using J = mp11::mp_find<mp11::mp_list<T...>, mp11::mp_at<mp11::mp_list<U...>, I>>;
+      this_->_replace(J{}, r._get_impl(i));
+    }
+  };
+
+public:
+  template <class... U,
+            class E2 = mp11::mp_if<mp11::mp_all<std::is_copy_constructible<U>...,
+                                                mp11::mp_contains<mp11::mp_list<T...>, U>...>,
+                                   void>>
+  variant(variant<U...> const& r) noexcept(
+    mp11::mp_all<std::is_nothrow_copy_constructible<U>...>::value)
+  {
+    mp11::mp_with_index<sizeof...(U)>(r.index(), L6<U...>{this, r});
+  }
+
+private:
+  template <class... U>
+  struct L7
+  {
+    variant_base*  this_;
+    variant<U...>& r;
+
+    template <class I>
+    void
+    operator()(I i) const
+    {
+      using J = mp11::mp_find<mp11::mp_list<T...>, mp11::mp_at<mp11::mp_list<U...>, I>>;
+      this_->_replace(J{}, std::move(r._get_impl(i)));
+    }
+  };
+
+public:
+  template <class... U,
+            class E2 = mp11::mp_if<mp11::mp_all<std::is_move_constructible<U>...,
+                                                mp11::mp_contains<mp11::mp_list<T...>, U>...>,
+                                   void>>
+  variant(variant<U...>&& r) noexcept(mp11::mp_all<std::is_nothrow_move_constructible<U>...>::value)
+  {
+    mp11::mp_with_index<sizeof...(U)>(r.index(), L7<U...>{this, r});
+  }
+
+  // subset (extension)
+
+private:
+  template <class... U,
+            class V,
+            std::size_t J,
+            class E = typename std::enable_if<J != sizeof...(U)>::type>
+  static constexpr variant<U...>
+  _subset_impl(mp11::mp_size_t<J>, V&& v)
+  {
+    return variant<U...>(in_place_index_t<J>(), std::forward<V>(v));
+  }
+
+  template <class... U, class V>
+  static variant<U...>
+  _subset_impl(mp11::mp_size_t<sizeof...(U)>, V&& /*v*/)
+  {
+    throw bad_variant_access();
+  }
+
+private:
+  template <class... U>
+  struct L8
+  {
+    variant* this_;
+
+    template <class I>
+    variant<U...>
+    operator()(I i) const
+    {
+      using J = mp11::mp_find<mp11::mp_list<U...>, mp11::mp_at<mp11::mp_list<T...>, I>>;
+      return this_->_subset_impl<U...>(J{}, this_->_get_impl(i));
+    }
+  };
+
+public:
+  template <class... U,
+            class E2 = mp11::mp_if<mp11::mp_all<std::is_copy_constructible<U>...,
+                                                mp11::mp_contains<mp11::mp_list<T...>, U>...>,
+                                   void>>
+  BOOST_CXX14_CONSTEXPR variant<U...>
+                        subset() &
+  {
+    return mp11::mp_with_index<sizeof...(T)>(index(), L8<U...>{this});
+  }
+
+private:
+  template <class... U>
+  struct L9
+  {
+    variant const* this_;
+
+    template <class I>
+    variant<U...>
+    operator()(I i) const
+    {
+      using J = mp11::mp_find<mp11::mp_list<U...>, mp11::mp_at<mp11::mp_list<T...>, I>>;
+      return this_->_subset_impl<U...>(J{}, this_->_get_impl(i));
+    }
+  };
+
+public:
+  template <class... U,
+            class E2 = mp11::mp_if<mp11::mp_all<std::is_copy_constructible<U>...,
+                                                mp11::mp_contains<mp11::mp_list<T...>, U>...>,
+                                   void>>
+  constexpr variant<U...>
+  subset() const&
+  {
+    return mp11::mp_with_index<sizeof...(T)>(index(), L9<U...>{this});
+  }
+
+private:
+  template <class... U>
+  struct L10
+  {
+    variant* this_;
+
+    template <class I>
+    variant<U...>
+    operator()(I i) const
+    {
+      using J = mp11::mp_find<mp11::mp_list<U...>, mp11::mp_at<mp11::mp_list<T...>, I>>;
+      return this_->_subset_impl<U...>(J{}, std::move(this_->_get_impl(i)));
+    }
+  };
+
+public:
+  template <class... U,
+            class E2 = mp11::mp_if<mp11::mp_all<std::is_copy_constructible<U>...,
+                                                mp11::mp_contains<mp11::mp_list<T...>, U>...>,
+                                   void>>
+  BOOST_CXX14_CONSTEXPR variant<U...>
+                        subset() &&
+  {
+    return mp11::mp_with_index<sizeof...(T)>(index(), L10<U...>{this});
+  }
+
+#if !BOOST_WORKAROUND(BOOST_GCC, < 40900)
+
+  // g++ 4.8 doesn't handle const&& particularly well
+
+private:
+  template <class... U>
+  struct L11
+  {
+    variant const* this_;
+
+    template <class I>
+    variant<U...>
+    operator()(I i) const
+    {
+      using J = mp11::mp_find<mp11::mp_list<U...>, mp11::mp_at<mp11::mp_list<T...>, I>>;
+      return this_->_subset_impl<U...>(J{}, std::move(this_->_get_impl(i)));
+    }
+  };
+
+public:
+  template <class... U,
+            class E2 = mp11::mp_if<mp11::mp_all<std::is_copy_constructible<U>...,
+                                                mp11::mp_contains<mp11::mp_list<T...>, U>...>,
+                                   void>>
+  constexpr variant<U...>
+  subset() const&&
+  {
+    return mp11::mp_with_index<sizeof...(T)>(index(), L11<U...>{this});
+  }
+
+#endif
+};
+
+// relational operators
+
+namespace detail
+{
+template <class... T>
+struct eq_L
+{
+  variant<T...> const& v;
+  variant<T...> const& w;
+
+  template <class I>
+  bool
+  operator()(I i) const
+  {
+    return v._get_impl(i) == w._get_impl(i);
+  }
+};
+
+} // namespace detail
+
+template <class... T>
+constexpr bool
+operator==(variant<T...> const& v, variant<T...> const& w)
+{
+  return v.index() == w.index() &&
+         mp11::mp_with_index<sizeof...(T)>(v.index(), detail::eq_L<T...>{v, w});
+}
+
+namespace detail
+{
+template <class... T>
+struct ne_L
+{
+  variant<T...> const& v;
+  variant<T...> const& w;
+
+  template <class I>
+  bool
+  operator()(I i) const
+  {
+    return v._get_impl(i) != w._get_impl(i);
+  }
+};
+
+} // namespace detail
+
+template <class... T>
+constexpr bool
+operator!=(variant<T...> const& v, variant<T...> const& w)
+{
+  return v.index() != w.index() ||
+         mp11::mp_with_index<sizeof...(T)>(v.index(), detail::ne_L<T...>{v, w});
+}
+
+namespace detail
+{
+template <class... T>
+struct lt_L
+{
+  variant<T...> const& v;
+  variant<T...> const& w;
+
+  template <class I>
+  bool
+  operator()(I i) const
+  {
+    return v._get_impl(i) < w._get_impl(i);
+  }
+};
+
+} // namespace detail
+
+template <class... T>
+constexpr bool
+operator<(variant<T...> const& v, variant<T...> const& w)
+{
+  return v.index() < w.index() ||
+         (v.index() == w.index() &&
+          mp11::mp_with_index<sizeof...(T)>(v.index(), detail::lt_L<T...>{v, w}));
+}
+
+template <class... T>
+constexpr bool
+operator>(variant<T...> const& v, variant<T...> const& w)
+{
+  return w < v;
+}
+
+namespace detail
+{
+template <class... T>
+struct le_L
+{
+  variant<T...> const& v;
+  variant<T...> const& w;
+
+  template <class I>
+  bool
+  operator()(I i) const
+  {
+    return v._get_impl(i) <= w._get_impl(i);
+  }
+};
+
+} // namespace detail
+
+template <class... T>
+constexpr bool
+operator<=(variant<T...> const& v, variant<T...> const& w)
+{
+  return v.index() < w.index() ||
+         (v.index() == w.index() &&
+          mp11::mp_with_index<sizeof...(T)>(v.index(), detail::le_L<T...>{v, w}));
+}
+
+template <class... T>
+constexpr bool
+operator>=(variant<T...> const& v, variant<T...> const& w)
+{
+  return w <= v;
+}
+
+// visitation
+namespace detail
+{
+template <class T>
+using remove_cv_ref_t = typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+
+template <class T, class U>
+struct copy_cv_ref
+{
+  using type = T;
+};
+
+template <class T, class U>
+struct copy_cv_ref<T, U const>
+{
+  using type = T const;
+};
+
+template <class T, class U>
+struct copy_cv_ref<T, U volatile>
+{
+  using type = T volatile;
+};
+
+template <class T, class U>
+struct copy_cv_ref<T, U const volatile>
+{
+  using type = T const volatile;
+};
+
+template <class T, class U>
+struct copy_cv_ref<T, U&>
+{
+  using type = typename copy_cv_ref<T, U>::type&;
+};
+
+template <class T, class U>
+struct copy_cv_ref<T, U&&>
+{
+  using type = typename copy_cv_ref<T, U>::type&&;
+};
+
+template <class T, class U>
+using copy_cv_ref_t = typename copy_cv_ref<T, U>::type;
+
+template <class F>
+struct Qret
+{
+  template <class... T>
+  using fn = decltype(std::declval<F>()(std::declval<T>()...));
+};
+
+template <class L>
+using front_if_same = mp11::mp_if<mp11::mp_apply<mp11::mp_same, L>, mp11::mp_front<L>>;
+
+template <class V>
+using apply_cv_ref = mp11::mp_product<copy_cv_ref_t, remove_cv_ref_t<V>, mp11::mp_list<V>>;
+
+template <class F, class... V>
+using Vret = front_if_same<mp11::mp_product_q<Qret<F>, apply_cv_ref<V>...>>;
+
+} // namespace detail
+
+template <class F>
+constexpr auto
+visit(F&& f) -> decltype(std::forward<F>(f)())
+{
+  return std::forward<F>(f)();
+}
+
+namespace detail
+{
+template <class F, class V1>
+struct visit_L1
+{
+  F&&  f;
+  V1&& v1;
+
+  template <class I>
+  auto operator()(I) const -> Vret<F, V1>
+  {
+    return std::forward<F>(f)(unsafe_get<I::value>(std::forward<V1>(v1)));
+  }
+};
+
+} // namespace detail
+
+template <class F, class V1>
+constexpr auto
+visit(F&& f, V1&& v1) -> detail::Vret<F, V1>
+{
+  return mp11::mp_with_index<variant_size<V1>>(
+    v1.index(), detail::visit_L1<F, V1>{std::forward<F>(f), std::forward<V1>(v1)});
+}
+
+#if defined(BOOST_NO_CXX14_GENERIC_LAMBDAS) || BOOST_WORKAROUND(BOOST_MSVC, < 1920)
+
+namespace detail
+{
+template <class F, class A>
+struct bind_front_
+{
+  F&& f;
+  A&& a;
+
+  template <class... T>
+  auto
+  operator()(T&&... t) -> decltype(std::forward<F>(f)(std::forward<A>(a), std::forward<T>(t)...))
+  {
+    return std::forward<F>(f)(std::forward<A>(a), std::forward<T>(t)...);
+  }
+};
+
+template <class F, class A>
+bind_front_<F, A>
+bind_front(F&& f, A&& a)
+{
+  return bind_front_<F, A>{std::forward<F>(f), std::forward<A>(a)};
+}
+
+template <class F, class V1, class V2>
+struct visit_L2
+{
+  F&& f;
+
+  V1&& v1;
+  V2&& v2;
+
+  template <class I>
+  auto operator()(I) const -> Vret<F, V1, V2>
+  {
+    auto f2 = bind_front(std::forward<F>(f), unsafe_get<I::value>(std::forward<V1>(v1)));
+    return visit(f2, std::forward<V2>(v2));
+  }
+};
+
+} // namespace detail
+
+template <class F, class V1, class V2>
+constexpr auto
+visit(F&& f, V1&& v1, V2&& v2) -> detail::Vret<F, V1, V2>
+{
+  return mp11::mp_with_index<variant_size<V1>>(
+    v1.index(),
+    detail::visit_L2<F, V1, V2>{std::forward<F>(f), std::forward<V1>(v1), std::forward<V2>(v2)});
+}
+
+namespace detail
+{
+template <class F, class V1, class V2, class V3>
+struct visit_L3
+{
+  F&& f;
+
+  V1&& v1;
+  V2&& v2;
+  V3&& v3;
+
+  template <class I>
+  auto operator()(I) const -> Vret<F, V1, V2, V3>
+  {
+    auto f2 = bind_front(std::forward<F>(f), unsafe_get<I::value>(std::forward<V1>(v1)));
+    return visit(f2, std::forward<V2>(v2), std::forward<V3>(v3));
+  }
+};
+
+} // namespace detail
+
+template <class F, class V1, class V2, class V3>
+constexpr auto
+visit(F&& f, V1&& v1, V2&& v2, V3&& v3) -> detail::Vret<F, V1, V2, V3>
+{
+  return mp11::mp_with_index<variant_size<V1>>(
+    v1.index(), detail::visit_L3<F, V1, V2, V3>{std::forward<F>(f), std::forward<V1>(v1),
+                                                std::forward<V2>(v2), std::forward<V3>(v3)});
+}
+
+namespace detail
+{
+template <class F, class V1, class V2, class V3, class V4>
+struct visit_L4
+{
+  F&& f;
+
+  V1&& v1;
+  V2&& v2;
+  V3&& v3;
+  V4&& v4;
+
+  template <class I>
+  auto operator()(I) const -> Vret<F, V1, V2, V3, V4>
+  {
+    auto f2 = bind_front(std::forward<F>(f), unsafe_get<I::value>(std::forward<V1>(v1)));
+    return visit(f2, std::forward<V2>(v2), std::forward<V3>(v3), std::forward<V4>(v4));
+  }
+};
+
+} // namespace detail
+
+template <class F, class V1, class V2, class V3, class V4>
+constexpr auto
+visit(F&& f, V1&& v1, V2&& v2, V3&& v3, V4&& v4) -> detail::Vret<F, V1, V2, V3, V4>
+{
+  return mp11::mp_with_index<variant_size<V1>>(
+    v1.index(), detail::visit_L4<F, V1, V2, V3, V4>{std::forward<F>(f), std::forward<V1>(v1),
+                                                    std::forward<V2>(v2), std::forward<V3>(v3),
+                                                    std::forward<V4>(v4)});
+}
+
+#else
+
+template <class F, class V1, class V2, class... V>
+constexpr auto
+visit(F&& f, V1&& v1, V2&& v2, V&&... v) -> detail::Vret<F, V1, V2, V...>
+{
+  return mp11::mp_with_index<variant_size<V1>>(v1.index(), [&](auto I) {
+    auto f2 = [&](auto&&... a) {
+      return std::forward<F>(f)(detail::unsafe_get<I.value>(std::forward<V1>(v1)),
+                                std::forward<decltype(a)>(a)...);
+    };
+    return visit(f2, std::forward<V2>(v2), std::forward<V>(v)...);
+  });
+}
+
+#endif
+
+// specialized algorithms
+template <class... T,
+          class E = typename std::enable_if<mp11::mp_all<std::is_move_constructible<T>...,
+                                                         detail::is_swappable<T>...>::value>::type>
+void
+swap(variant<T...>& v, variant<T...>& w) noexcept(noexcept(v.swap(w)))
+{
+  v.swap(w);
+}
+
+} // namespace variant2
+} // namespace boost
+
+#if defined(_MSC_VER) && _MSC_VER < 1910
+#pragma warning(pop)
+#endif
+
+#endif // #ifndef BOOST_VARIANT2_VARIANT_HPP_INCLUDED

--- a/include/foxy/multi_stream.hpp
+++ b/include/foxy/multi_stream.hpp
@@ -68,7 +68,7 @@ public:
   async_read_some(MutableBufferSequence const& buffers, CompletionToken&& token)
   {
     return boost::variant2::visit(
-      [&](auto& stream) mutable {
+      [&](auto& stream) {
         return stream.async_read_some(buffers, std::forward<CompletionToken>(token));
       },
       stream_);
@@ -79,7 +79,7 @@ public:
   async_write_some(ConstBufferSequence const& buffers, CompletionToken&& token)
   {
     return boost::variant2::visit(
-      [&](auto& stream) mutable {
+      [&](auto& stream) {
         return stream.async_write_some(buffers, std::forward<CompletionToken>(token));
       },
       stream_);
@@ -130,8 +130,7 @@ template <class Stream, class X>
 auto
 basic_multi_stream<Stream, X>::get_executor() -> boost::asio::io_context::executor_type
 {
-  return boost::variant2::visit([&](auto& stream) mutable { return stream.get_executor(); },
-                                stream_);
+  return boost::variant2::visit([](auto& stream) { return stream.get_executor(); }, stream_);
 }
 
 using multi_stream = basic_multi_stream<boost::asio::ip::tcp::socket>;

--- a/include/foxy/multi_stream.hpp
+++ b/include/foxy/multi_stream.hpp
@@ -1,15 +1,16 @@
 //
-// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot
-// com)
+// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot com)
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 // Official repository: https://github.com/LeonineKing1199/foxy
 //
 
 #ifndef FOXY_MULTI_STREAM_HPP_
 #define FOXY_MULTI_STREAM_HPP_
+
+#include <foxy/detail/variant2/variant.hpp>
 
 #include <boost/asio/io_context.hpp>
 
@@ -19,18 +20,12 @@
 #include <boost/asio/ssl/context.hpp>
 #include <boost/beast/experimental/core/ssl_stream.hpp>
 
-#include <boost/variant/get.hpp>
-#include <boost/variant/variant.hpp>
-#include <boost/variant/apply_visitor.hpp>
-
 #include <utility>
 #include <type_traits>
 
 namespace foxy
 {
-template <class Stream,
-          class =
-            std::enable_if_t<boost::beast::is_async_stream<Stream>::value>>
+template <class Stream, class = std::enable_if_t<boost::beast::is_async_stream<Stream>::value>>
 struct basic_multi_stream
 {
 public:
@@ -39,7 +34,7 @@ public:
   using executor_type   = boost::asio::io_context::executor_type;
 
 private:
-  boost::variant<stream_type, ssl_stream_type> stream_;
+  boost::variant2::variant<stream_type, ssl_stream_type> stream_;
 
 public:
   basic_multi_stream()                          = delete;
@@ -72,10 +67,9 @@ public:
   auto
   async_read_some(MutableBufferSequence const& buffers, CompletionToken&& token)
   {
-    return boost::apply_visitor(
+    return boost::variant2::visit(
       [&](auto& stream) mutable {
-        return stream.async_read_some(buffers,
-                                      std::forward<CompletionToken>(token));
+        return stream.async_read_some(buffers, std::forward<CompletionToken>(token));
       },
       stream_);
   }
@@ -84,10 +78,9 @@ public:
   auto
   async_write_some(ConstBufferSequence const& buffers, CompletionToken&& token)
   {
-    return boost::apply_visitor(
+    return boost::variant2::visit(
       [&](auto& stream) mutable {
-        return stream.async_write_some(buffers,
-                                       std::forward<CompletionToken>(token));
+        return stream.async_write_some(buffers, std::forward<CompletionToken>(token));
       },
       stream_);
   }
@@ -105,9 +98,7 @@ basic_multi_stream<Stream, X>::basic_multi_stream(Arg&& arg)
 
 template <class Stream, class X>
 template <class Arg>
-basic_multi_stream<Stream, X>::basic_multi_stream(
-  Arg&&                      arg,
-  boost::asio::ssl::context& ctx)
+basic_multi_stream<Stream, X>::basic_multi_stream(Arg&& arg, boost::asio::ssl::context& ctx)
   : stream_(ssl_stream_type(std::forward<Arg>(arg), ctx))
 {
 }
@@ -117,7 +108,7 @@ template <class Stream, class X>
   basic_multi_stream<Stream, X>::plain() &
   noexcept -> stream_type&
 {
-  return boost::get<stream_type>(stream_);
+  return boost::variant2::get<stream_type>(stream_);
 }
 
 template <class Stream, class X>
@@ -125,23 +116,22 @@ template <class Stream, class X>
   basic_multi_stream<Stream, X>::ssl() &
   noexcept -> ssl_stream_type&
 {
-  return boost::get<ssl_stream_type>(stream_);
+  return boost::variant2::get<ssl_stream_type>(stream_);
 }
 
 template <class Stream, class X>
 auto
 basic_multi_stream<Stream, X>::is_ssl() const noexcept -> bool
 {
-  return stream_.which() == 1;
+  return stream_.index() == 1;
 }
 
 template <class Stream, class X>
 auto
-basic_multi_stream<Stream, X>::get_executor()
-  -> boost::asio::io_context::executor_type
+basic_multi_stream<Stream, X>::get_executor() -> boost::asio::io_context::executor_type
 {
-  return boost::apply_visitor(
-    [&](auto& stream) mutable { return stream.get_executor(); }, stream_);
+  return boost::variant2::visit([&](auto& stream) mutable { return stream.get_executor(); },
+                                stream_);
 }
 
 using multi_stream = basic_multi_stream<boost::asio::ip::tcp::socket>;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,18 +1,23 @@
 //
-// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot
-// com)
+// Copyright (c) 2018-2019 Christian Mazakas (christian dot mazakas at gmail dot com)
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 // Official repository: https://github.com/LeonineKing1199/foxy
 //
 
 #include <foxy/log.hpp>
+#include <boost/asio/ssl/error.hpp>
+
+namespace net = boost::asio;
 
 auto
-foxy::log_error(boost::system::error_code const ec,
-                boost::string_view const        what) -> void
+foxy::log_error(boost::system::error_code const ec, boost::string_view const what) -> void
 {
+  // don't bother printing ssl short reads
+  // if an SSL stream truly _is_ truncated, Beast's parser errors out with a partial_message
+  //
+  if (ec == net::ssl::error::stream_truncated) { return; }
   std::cerr << what << " : " << ec.message() << "\n";
 }


### PR DESCRIPTION
This PR adds pdimov's Variant2 to Foxy.

We change the implementation to allow for the socket type to be switched at runtime for the `foxy::basic_multi_stream`. Boost.Variant's move assignment operator and constructor require `noexcept`-qualified move operators for the underlying type. Asio's I/O objects do not support this