### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,53 @@
 sudo: enabled
 
 language: cpp
+os: linux
+dist: xenial
 
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - ninja-build
+    - curl
+    - python3
 # safelist
 branches:
   only:
   - master
   - develop
 
-services:
-  - docker
-
-before_install:
-  - docker pull leonineking1199/foxy:boost-1.69
-  - docker run -it -d -v $(pwd):$(pwd):rw --workdir=$(pwd) --name foxy leonineking1199/foxy:boost-1.69 bash
+before_script:
+  - echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" |sudo tee -a /etc/apt/sources.list
+  - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |sudo apt-key add -
+  - sudo apt-get -qq update
+  - sudo apt-get -y install clang-9 lld-9
 
 script:
-  - docker exec foxy mkdir build_debug
-  - docker exec foxy bash -c "cd build_debug && /cmake-3.13.4-Linux-x86_64/bin/cmake -DVCPKG_TARGET_TRIPLET=x64-linux-cxx14 -DCMAKE_TOOLCHAIN_FILE=../foxy-travis.cmake .. && /cmake-3.13.4-Linux-x86_64/bin/cmake --build . && /cmake-3.13.4-Linux-x86_64/bin/ctest ."
+  - wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.tar.gz
+  - tar xf cmake-3.15.5-Linux-x86_64.tar.gz
+  - wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.bz2
+  - tar xf boost_1_71_0.tar.bz2
+  - cd boost_1_71_0
+  - ./bootstrap.sh --prefix=./out
+  - ./b2 --stagedir=. --layout=system --with-atomic --with-date_time --with-system --with-coroutine --with-thread --with-container -j2 link=static stage
+  - cd ..
+  - wget https://github.com/catchorg/Catch2/archive/v2.10.2.tar.gz
+  - tar xf v2.10.2.tar.gz
+  - cd Catch2-2.10.2
+  - mkdir -p build
+  - cd build
+  - cmake -DCATCH_BUILD_TESTING=OFF -DCATCH_ENABLE_WERROR=OFF -DCATCH_INSTALL_DOCS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_C_COMPILER=clang-9 -DCMAKE_CXX_COMPILER=clang++-9 -G Ninja ..
+  - ninja
+  - sudo ninja install
+  - cd ../..
+  - mkdir -p build
+  - cd build
+  - ../cmake-3.15.5-Linux-x86_64/bin/cmake --version
+  - ../cmake-3.15.5-Linux-x86_64/bin/cmake -G Ninja -DBUILD_TESTING=ON -DCMAKE_C_COMPILER=clang-9 -DCMAKE_CXX_COMPILER=clang++-9 -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DBOOST_INCLUDEDIR=$TRAVIS_BUILD_DIR/boost_1_71_0 _DBOOST_LIBRARYDIR=$TRAVIS_BUILD_DIR/boost_1_71_0/lib ..
+  - ninja
+  - ./foxy_tests
 
 notifications:
   email:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ add_library(
 target_include_directories(test_utils PUBLIC test/include)
 target_link_libraries(test_utils PUBLIC foxy)
 
+option(BUILD_TESTING "Build Foxy Testsuite" OFF)
 if (BUILD_TESTING)
   include(CTest)
 
@@ -201,6 +202,7 @@ if (BUILD_TESTING)
       Boost::container
   )
 
+  file(COPY test/root-cas.pem DESTINATION ${CMAKE_BINARY_DIR})
   include(Catch)
   catch_discover_tests(foxy_tests)
 endif()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Foxy
+# Foxy [![Build Status](https://travis-ci.org/LeonineKing1199/foxy.svg?branch=develop)](https://travis-ci.org/LeonineKing1199/foxy)
 
 Low-level HTTP session primitives for Beast/Asio + URL parsing and pct-coding
 


### PR DESCRIPTION
The Travis CI definition file now correctly pulls in needed dependencies
and uses them to build the application.

Tests are also built and executed as part of the build process.