### PR TITLE
Add ci builds for current ubuntu releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,79 @@
-sudo: enabled
-
 language: cpp
-os: linux
-dist: xenial
+matrix:
+  include:
+    - name: "ubuntu20: gcc"
+      dist: focal
+      compiler : gcc
+    - name: "ubuntu20: clang"
+      dist: focal
+      compiler : clang 
+    - name: "ubuntu18: gcc"
+      dist: bionic 
+      compiler : gcc
+      before_script:
+        - sudo apt-get install -y wget tar 
+        - wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.tar.gz
+        - tar xf cmake-3.15.5-Linux-x86_64.tar.gz
+        - export PATH="${PWD}/cmake-3.15.5-Linux-x86_64/bin/:${PATH}"
+    - name: "ubuntu18: clang"
+      dist: bionic 
+      compiler : clang 
+      before_script:
+        - sudo apt-get install -y wget tar 
+        - wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.tar.gz
+        - tar xf cmake-3.15.5-Linux-x86_64.tar.gz
+        - export PATH="${PWD}/cmake-3.15.5-Linux-x86_64/bin/:${PATH}"
+    - name: "ubuntu16: clang"
+      os: linux
+      dist: xenial
+      sudo: enabled
+      addons:
+        apt:
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - ninja-build
+          - curl
+          - python3
+      before_script:
+        - echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" |sudo tee -a /etc/apt/sources.list
+        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |sudo apt-key add -
+        - sudo apt-get -qq update
+        - sudo apt-get -y install clang-9 lld-9
+      script:
+        - wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.tar.gz
+        - tar xf cmake-3.15.5-Linux-x86_64.tar.gz
+        - wget https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2
+        - tar xf boost_1_75_0.tar.bz2
+        - cd boost_1_75_0
+        - ./bootstrap.sh --prefix=./out
+        - ./b2 --stagedir=. --layout=system --with-atomic --with-date_time --with-system --with-coroutine --with-thread --with-container -j2 link=static stage
+        - cd ..
+        - wget https://github.com/catchorg/Catch2/archive/v2.10.2.tar.gz
+        - tar xf v2.10.2.tar.gz
+        - cd Catch2-2.10.2
+        - mkdir -p build
+        - cd build
+        - cmake -DCATCH_BUILD_TESTING=OFF -DCATCH_ENABLE_WERROR=OFF -DCATCH_INSTALL_DOCS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_C_COMPILER=clang-9 -DCMAKE_CXX_COMPILER=clang++-9 -G Ninja ..
+        - ninja
+        - sudo ninja install
+        - cd ../..
+        - mkdir -p build
+        - cd build
+        - ../cmake-3.15.5-Linux-x86_64/bin/cmake --version
+        - ../cmake-3.15.5-Linux-x86_64/bin/cmake -G Ninja -DBUILD_TESTING=ON -DCMAKE_C_COMPILER=clang-9 -DCMAKE_CXX_COMPILER=clang++-9 -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DBOOST_INCLUDEDIR=$TRAVIS_BUILD_DIR/boost_1_75_0 _DBOOST_LIBRARYDIR=$TRAVIS_BUILD_DIR/boost_1_75_0/lib ..
+        - ninja
+        - ./foxy_tests
 
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - ninja-build
-    - curl
-    - python3
-
-before_script:
-  - echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" |sudo tee -a /etc/apt/sources.list
-  - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key |sudo apt-key add -
-  - sudo apt-get -qq update
-  - sudo apt-get -y install clang-9 lld-9
-
-script:
-  - wget https://github.com/Kitware/CMake/releases/download/v3.15.5/cmake-3.15.5-Linux-x86_64.tar.gz
-  - tar xf cmake-3.15.5-Linux-x86_64.tar.gz
-  - wget https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2
-  - tar xf boost_1_75_0.tar.bz2
-  - cd boost_1_75_0
-  - ./bootstrap.sh --prefix=./out
-  - ./b2 --stagedir=. --layout=system --with-atomic --with-date_time --with-system --with-coroutine --with-thread --with-container -j2 link=static stage
-  - cd ..
-  - wget https://github.com/catchorg/Catch2/archive/v2.10.2.tar.gz
-  - tar xf v2.10.2.tar.gz
-  - cd Catch2-2.10.2
-  - mkdir -p build
-  - cd build
-  - cmake -DCATCH_BUILD_TESTING=OFF -DCATCH_ENABLE_WERROR=OFF -DCATCH_INSTALL_DOCS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_C_COMPILER=clang-9 -DCMAKE_CXX_COMPILER=clang++-9 -G Ninja ..
-  - ninja
-  - sudo ninja install
-  - cd ../..
-  - mkdir -p build
-  - cd build
-  - ../cmake-3.15.5-Linux-x86_64/bin/cmake --version
-  - ../cmake-3.15.5-Linux-x86_64/bin/cmake -G Ninja -DBUILD_TESTING=ON -DCMAKE_C_COMPILER=clang-9 -DCMAKE_CXX_COMPILER=clang++-9 -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DBOOST_INCLUDEDIR=$TRAVIS_BUILD_DIR/boost_1_75_0 _DBOOST_LIBRARYDIR=$TRAVIS_BUILD_DIR/boost_1_75_0/lib ..
-  - ninja
+script: 
+  - export LD_LIBRARY_PATH=$(pwd)/build/devroot/lib:${LD_LIBRARY_PATH}
+  - cmake -DBUILD_TESTING=ON -S tools/cmake-superbuild -B build 
+  - cmake --build build -j$(nproc) 
+  - cd build/foxy-prefix/src/foxy-build
   - ./foxy_tests
 
+jobs:
+  include :
 notifications:
   email:
     false

--- a/docs/building.md
+++ b/docs/building.md
@@ -3,6 +3,18 @@
 Foxy has only a few non-trivial dependencies. Namely, [Boost](https://github.com/boostorg/boost) and
 OpenSSL.
 
+These dependencies can be automatically built using the 
+[tools/cmake-superbuild](../tools/cmake-superbuild/CMakelists.txt) project. This 
+project simply builds the dependencies and installs them to a local build folder 
+before building foxy. You just need to install a recent toolchain and cmake then run:
+```bash
+cmake -S tools/cmake-superbuild -B build 
+cmake --build build
+```
+
+Alternatively you can install these dependencies into you host system as 
+follows:
+
 ## OpenSSL
 
 OpenSSL is found via CMake's [FindOpenSSL](https://cmake.org/cmake/help/latest/module/FindOpenSSL.html)

--- a/tools/cmake-superbuild/CMakeLists.txt
+++ b/tools/cmake-superbuild/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.0)
+project(foxy-super)
+include(ExternalProject)
+
+set(DEVROOT ${CMAKE_BINARY_DIR}/devroot)
+
+set(CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=Debug
+        -DCMAKE_PREFIX_PATH=${DEVROOT}
+        -DCMAKE_INSTALL_PREFIX=${DEVROOT}
+        )
+
+ExternalProject_Add(
+        boost
+	URL https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2
+	URL_HASH SHA256=953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb
+        BUILD_IN_SOURCE 1
+        UPDATE_COMMAND ""
+        CONFIGURE_COMMAND ./bootstrap.sh --prefix=${DEVROOT}
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ./b2 --prefix=${DEVROOT}
+                             --with-atomic 
+                             --with-date_time 
+                             --with-system 
+                             --with-coroutine 
+                             --with-thread 
+                             --with-container 
+                             --j$(nproc) install
+)
+
+ExternalProject_Add(
+        catch2
+        URL https://github.com/catchorg/Catch2/archive/v2.13.3.tar.gz
+        URL_HASH SHA256=fedc5b008f7eb574f45098e7c7138211c543f0f8ad04792090e790511697a877
+        CMAKE_ARGS ${CMAKE_ARGS}
+            -DCATCH_BUILD_TESTING=OFF
+            -DCATCH_ENABLE_WERROR=OFF
+            -DCATCH_INSTALL_DOCS=OFF
+)
+
+ExternalProject_Add(
+        openssl 
+        URL https://www.openssl.org/source/openssl-1.1.1i.tar.gz
+	URL_HASH SHA1=eb684ba4ed31fe2c48062aead75233ecd36882a6
+	CONFIGURE_COMMAND <SOURCE_DIR>/config --prefix=${DEVROOT}
+	BUILD_COMMAND make -j1
+	INSTALL_COMMAND make install 
+)
+
+ExternalProject_Add(
+        foxy
+        DEPENDS catch2 boost openssl
+        SOURCE_DIR ..
+        CMAKE_ARGS ${CMAKE_ARGS} -DBUILD_TESTING=ON
+)


### PR DESCRIPTION
* add cmake-superbuild for easier building of dependencies
* build in travis-ci for
  * clang and gcc, on both
  * ubuntu focal (20) and bionic (18)